### PR TITLE
Add stat field query option

### DIFF
--- a/web/css/query.css
+++ b/web/css/query.css
@@ -1,6 +1,6 @@
 :root {
 	--search-bar-padding: 20px;
-	--query-parameter-container-height: 300px;
+	--query-parameter-container-height: 400px;
 }
 @import './climberdb.css';
 
@@ -221,6 +221,15 @@ height of the container, so make sure it aligns with the bottom of the rest of t
 	background: rgba(255, 255, 255, 0.3);
 }
 
+.stat-field-row {
+	width: 100%;
+	display: flex;
+	margin-top: 20px;
+}
+.stat-field-row.cloneable {
+	display: none;
+}
+
 /*resize bar*/
 .dragbar.vertical-resize {
 	width: 100%;
@@ -233,7 +242,7 @@ height of the container, so make sure it aligns with the bottom of the rest of t
 	height: 100%;
 	width: 100%;
 	background-color: var(--ui-primary-color);
-	opacity: 0;
+	opacity: 0.1;
 	transition: 0.2s all ease-in 0.1s;
 }
 /*.dragbar.vertical-resize:hover,

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -447,6 +447,30 @@ class ClimberDBExpeditions extends ClimberDB {
 			}
 		});
 
+		// When a user changes the highest_elevation_ft field, check/uncheck the Summited checkbox
+		$('.input-field[name=highest_elevation_ft]').change(e => {
+			const $highestElevationInput = $(e.target);
+			const highestElevation = $highestElevationInput.val();
+			const $card = $highestElevationInput.closest('.card');
+			const mountainCode = $card.find('.input-field[name=mountain_code]').val();
+			const summitElavation = this.mountainCodes[mountainCode].elevation_ft;
+			const $checkbox = $highestElevationInput.closest('.data-list-item').find('[name=route_was_summited]');
+
+			// Check to make sure the elvation entered is not greater than the summit elevation
+			if (highestElevation > summitElavation){
+				const message = `You entered a <em>Highest elevation</em> of <strong>${highestElevation}</strong>,` + 
+					` but the summit elevation is <strong>${summitElavation}</strong>. If the elevation you entered` + 
+					` is correct, you will have to manually check the <em>Summited?</em> checkbox. Otherwise,` +
+					` correct the <em>Highest elevation</em>`;
+				showModal(message, 'Invalid Highest Elevation')
+				return;
+			}
+
+			// Set the summitted checkbox based on whether the highest elev. value matches the
+			//	summit elev.
+			$checkbox.prop('checked', highestElevation == summitElavation).change();
+		});
+
 
 		// ask user to confirm removing CMC only if it already exists in the DB
 		$(document).on('click', '.delete-route-member-button', e => {

--- a/web/query.html
+++ b/web/query.html
@@ -184,7 +184,7 @@
 									<option value="climbers">Climbers</option>
 									<option value="expeditions">Expeditions</option>
 								</select>
-								<label class="field-label" for="count_per_guide_company-summary_or_records">What would you like to query?</label>
+								<label class="field-label" for="count_climbers-summary_or_records">What would you like to query?</label>
 							</div>
 							<div class="field-container col-sm col-md-4 col-lg-3 collapse show">
 								<select id="count_climbers-count_field" class="input-field no-option-fill" name="count_climbers-count_field" title="Count expedition members, climbers, or climbs?" data-dependent-target="#count_climbers-summary_or_records" data-dependent-value="summary" required>
@@ -466,6 +466,33 @@
 									<i class="fas fa-lg fa-times"></i>
 								</button>
 								<label class="field-label" for="count_climbers-actual_return_date_operator">Actual return</label>
+							</div>
+							<div class="field-container-row collapse show w-100">
+								<div class="w-100 d-flex justify-content-start">
+									<button id="add-numeric-stat-field-button" class="generic-button mt-3">Add calculated field</button>
+								</div>
+								<div class="stat-field-row cloneable" aria-hidden="true">
+									<div class="field-container col-sm-6 col-md-4 col-lg-3 pr-3">
+										<select class="input-field query-option-input-field is-empty numeric-stat-field-name no-option-fill default no-name-auto-update" name="numeric_stat_field" data-dependent-target="#count_climbers-summary_or_records" data-dependent-value="summary" required>
+											<option value="">Field name</option>
+											<option value="age">Climber age</option>
+											<option value="trip_length_days">Trip length (days)</option>
+										</select>
+										<label class="field-label" for="count_climbers-country_code">Field name</label>
+									</div>
+									<div class="field-container col-sm-6 col-md-4 col-lg-3 pr-3">
+										<select class="input-field query-option-input-field is-empty numeric-stat-name no-option-fill default no-name-auto-update" name="numeric_stat" placeholder="Statistic" required>
+											<option value="">Statistic</option>
+											<option value="avg">Average</option>
+											<option value="min">Minimum</option>
+											<option value="max">Maximum</option>
+										</select>
+										<button class="icon-button hide-query-parameter-button">
+											<i class="fas fa-lg fa-times"></i>
+										</button>
+										<label class="field-label" for="count_climbers-country_code">Statistic</label>
+									</div>
+								</div>
 							</div>
 						</div>
 


### PR DESCRIPTION
Enable users to add calculated statistics columns on numeric fields, namely _trip length_ and _climber age_. The "add stat field" button and all calculated stat rows are inside a collapse that is shown or hidden based on what the user is querying -- only a query that produces a `GROUP BY` clause will allow calculated stat fields.