### PR TITLE
Auto fill permit number

### DIFF
--- a/web/expeditions.html
+++ b/web/expeditions.html
@@ -335,7 +335,7 @@
 														</div>
 														<div class="field-container-row">
 															<div class="field-container col-sm-6">
-																<input id="input-permit_number" class="input-field" name="permit_number" data-table-name="expedition_members" placeholder="Permit number" title="Permit number" type="number" autocomplete="__never">
+																<input id="input-permit_number" class="input-field" name="permit_number" data-table-name="expedition_members" placeholder="Permit number" title="Permit number" type="text" autocomplete="__never">
 																<label class="field-label" for="input-permit_number">Permit number</label>
 																<span class="null-input-indicator">&lt; null &gt;</span>
 															</div>	

--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -549,8 +549,8 @@ def write_to_label_matrix():
 
 
 #---------------- DB I/O ---------------------#
-@app.route('/flask/permit_count', methods=['POST'])
-def get_permit_count():
+@app.route('/flask/next_permit_number', methods=['POST'])
+def get_next_permit_number():
 	
 	data = request.form
 	if not 'year' in data:
@@ -562,7 +562,7 @@ def get_permit_count():
 
 	sql = f'''
 		SELECT 
-			count(*) + 1 AS permit_count 
+		max(expedition_members.permit_number) AS max_permit 
 		FROM expedition_members 
 		JOIN expeditions ON expedition_members.expedition_id=expeditions.id
 		WHERE extract(year FROM planned_departure_date)={year}
@@ -571,10 +571,10 @@ def get_permit_count():
 		cursor = conn.execute(sql)
 		row = cursor.first()
 		if row:
-			# format dateime, then substitue encounter data and configuration values
-			return str(row['permit_count'])
+			# Permit format: TKA-YY-####. Just return just the number + 1
+			return str(int((row.max_permit or '0000').split('-')[-1]) + 1)
 		else:
-			raise ValueError(f'No expeditions in database for year {year}')
+			raise RuntimeError('Failed to get next permit number')
 
 #---------------- DB I/O ---------------------#
 

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -1420,32 +1420,47 @@ class ClimberDBExpeditions extends ClimberDB {
 		}
 
 		// Get expedition members and member transactions
-		//	Transactions and routes might have edits without expedition members having any, so loop 
-		//	through each expedition member card, regardless of whether it has any dirty inputs
-		for (const el of $('#expedition-members-accordion .card:not(.cloneable)')) {
-			const $card = $(el);
+		const year = new Date($('#input-planned_departure_date').val()).getFullYear();
+		let permitCount;
+		const permitNumbersFilled = $('input[name=permit_number]').map((_, el) => el.value).get().every(v => v);
+		const permitCountDeferred = permitNumbersFilled ? 
+			$.Deferred().resolve() : // resolve the promise immediately so the SQL save request doesn't wait
+			$.post({
+				url: 'flask/permit_count',
+				data: {year: year}
+			}).done(response => {
+				if (this.pythonReturnedError(response)) {
+					print('Failed to get next permit number with error: ' + response);
+				} else {
+					permitCount = response;
+				}
+			}).fail((xhr, status, error) => {
+				print('Failed to get next permit number with error: ' + error)
+			});
 
-			// expedition member
-			const dbID = $card.data('table-id');
+		// Make a convenience function to get SQL for expedition members because the method 
+		//	for doing so differs depending on whether the permit number needs to be filled 
+		//	for each individual expedition member in the for loop below. This needs to 
+		//	include transactions and route memebers so the SQL statements are in order. That is,
+		//	transactions and routes for an expedition member can't be INSERTed before the member
+		const getExpeditionMemberSQL = ($card) => {
 			const climberID = $card.data('climber-id');
-			if ($card.find('.card-header .input-field.dirty, .expedition-info-tab-pane .input-field.dirty').length) {
-				const [sql, parameters] = this.inputsToSQL(
-					$card.find('.expedition-info-tab-pane, .card-header'),
-					'expedition_members', 
-					now, 
-					userName, 
-					{
-						updateID: dbID || null, 
-						foreignIDs: {
-							expeditions: expeditionID, 
-							climbers: climberID
-						},
-						insertArray: inserts
-					}
-				);
-				sqlStatements.push(sql);
-				sqlParameters.push(parameters);
-			}
+			const [sql, parameters] = this.inputsToSQL(
+				$card.find('.expedition-info-tab-pane, .card-header'),
+				'expedition_members', 
+				now, 
+				userName, 
+				{
+					updateID: $card.data('table-id') || null, 
+					foreignIDs: {
+						expeditions: expeditionID, 
+						climbers: climberID
+					},
+					insertArray: inserts
+				}
+			);
+			sqlStatements.push(sql);
+			sqlParameters.push(parameters);
 
 			// transactions
 			for (const li of $card.find('.transactions-tab-pane .data-list > li.data-list-item:not(.cloneable)').has('.input-field.dirty')) {
@@ -1488,6 +1503,31 @@ class ClimberDBExpeditions extends ClimberDB {
 			}
 		}
 
+		// Transactions and routes might have edits without expedition members having any, so loop 
+		//	through each expedition member card, regardless of whether it has any dirty inputs
+		for (const el of $('#expedition-members-accordion .card:not(.cloneable)')) {
+			const $card = $(el);
+
+			// expedition member
+			const $permitNumberField = $card.find('input[name=permit_number]');
+			const permitNumberEmpty = !$permitNumberField.val();
+			// If the permit number field is empty, wait for the permit count request before getting SQL
+			if (permitNumberEmpty) {
+				permitCountDeferred.then(() => {
+					const thisPermitNumber = `TKA-${year.toString().slice(2,4)}-${String(permitCount).padStart(4, '0')}`;
+					$permitNumberField.val(thisPermitNumber)
+							.change();
+					permitCount ++; //increment for next permit
+					getExpeditionMemberSQL($card);
+				})
+			} 
+			// Otherwise, if there are other edits, just get the SQL immediately
+			else if ($card.find('.card-header .input-field.dirty, .expedition-info-tab-pane .input-field.dirty').length) {
+				getExpeditionMemberSQL($card);
+			}
+
+		}
+
 		// CMCs
 		for (const li of $('#cmc-list li.data-list-item:not(.cloneable)').has('.input-field.dirty')) {
 			const dbID = $(li).data('table-id');
@@ -1526,71 +1566,75 @@ class ClimberDBExpeditions extends ClimberDB {
 			sqlParameters.push(parameters);
 		}
 		
+		// Make sure, if permit numbers had to be created, that the request was 
+		//	answered first. If it wasn't necessary, the permitCountDeferred was
+		//	resolved immediately and the request to save the data will fire 
+		//	immediately as well
+		return permitCountDeferred.then(() => {
 
-		return $.ajax({ 
-			url: 'climberdb.php',
-			method: 'POST',
-			data: {action: 'paramQuery', queryString: sqlStatements, params: sqlParameters},
-			cache: false
-		}).done(queryResultString => {
-			if (climberDB.queryReturnedError(queryResultString)) { 
-				showModal(`An unexpected error occurred while saving data to the database: ${queryResultString.trim()}. Make sure you're still connected to the NPS network and try again. Contact your database adminstrator if the problem persists.`, 'Unexpected error');
-				return;
-			} else {
-				const result = $.parseJSON(queryResultString)
-					.filter(row => row != null);
-				var expeditionID = this.expeditionInfo.expeditions.id;
-				for (const i in result) {
-					const returnedIDs = result[i];
-					const id = returnedIDs.id;
-					if (id == null || id === '') continue;
+			return $.post({ 
+				url: 'climberdb.php',
+				data: {action: 'paramQuery', queryString: sqlStatements, params: sqlParameters},
+				cache: false
+			}).done(queryResultString => {
+				if (climberDB.queryReturnedError(queryResultString)) { 
+					showModal(`An unexpected error occurred while saving data to the database: ${queryResultString.trim()}. Make sure you're still connected to the NPS network and try again. Contact your database adminstrator if the problem persists.`, 'Unexpected error');
+					return;
+				} else {
+					const result = $.parseJSON(queryResultString)
+						.filter(row => row != null);
+					var expeditionID = this.expeditionInfo.expeditions.id;
+					for (const i in result) {
+						const returnedIDs = result[i];
+						const id = returnedIDs.id;
+						if (id == null || id === '') continue;
 
-					const {container, tableName} = inserts[i];
-					if (tableName === 'expeditions') {
-						expeditionID = id;
+						const {container, tableName} = inserts[i];
+						if (tableName === 'expeditions') {
+							expeditionID = id;
+							
+							// this was a new expedition, so add the expedition to the URL history
+							this.updateURLHistory(expeditionID, $('#expedition-id-input'));
+						}
+
+						// Set the card's/list item's class and inputs' attributes so changes will register as updates
+						const $container = $(container).closest('.data-list-item, .card');
+						const parentTableID = (this.tableInfo.tables[tableName].foreignColumns[0] || {}).column;
+						if ($container.is('.data-list-item')) $container.attr('data-parent-table-id', parentTableID); 
+						const $inputs = $container.closest('.data-list-item, .card')
+							.removeClass('new-card')
+							.removeClass('new-list-item')
+							.attr('data-table-id', id)
+							.attr('data-table-name', tableName)
+							.find('.input-field.dirty')
+								.attr('data-table-name', tableName)
+								.attr('data-table-id', id);
+						const foreignIDs = Object.entries(returnedIDs).filter(([column, _]) => column !== 'id');
+						if (Object.keys(foreignIDs).length) $inputs.data('foreign-ids', Object.fromEntries(foreignIDs));
 						
-						// this was a new expedition, so add the expedition to the URL history
-						this.updateURLHistory(expeditionID, $('#expedition-id-input'));
 					}
 
-					// Set the card's/list item's class and inputs' attributes so changes will register as updates
-					const $container = $(container).closest('.data-list-item, .card');
-					const parentTableID = (this.tableInfo.tables[tableName].foreignColumns[0] || {}).column;
-					if ($container.is('.data-list-item')) $container.attr('data-parent-table-id', parentTableID); 
-					const $inputs = $container.closest('.data-list-item, .card')
-						.removeClass('new-card')
-						.removeClass('new-list-item')
-						.attr('data-table-id', id)
-						.attr('data-table-name', tableName)
-						.find('.input-field.dirty')
-							.attr('data-table-name', tableName)
-							.attr('data-table-id', id);
-					const foreignIDs = Object.entries(returnedIDs).filter(([column, _]) => column !== 'id');
-					if (Object.keys(foreignIDs).length) $inputs.data('foreign-ids', Object.fromEntries(foreignIDs));
-					
+
+					// update in-memory data for each edited input
+					const edits = this.edits;
+					const expeditionInfo = this.expeditionInfo;
+					const $editedInputs =  $('.input-field.dirty').removeClass('dirty');
+					this.queryExpedition(expeditionID, {showOnLoadWarnings: false}) //suppress flagged expedition member warnings
+
+
+					// Hide the save button again since there aren't any edits
+					$('#save-expedition-button').ariaHide(true);
+					// but open the reports modal button since there's something to show
+					$('#open-reports-modal-button, #print-cache-tag-button, #edit-expedition-button, #delete-expedition-button').ariaHide(false);
+
 				}
-
-
-				// update in-memory data for each edited input
-				const edits = this.edits;
-				const expeditionInfo = this.expeditionInfo;
-				const $editedInputs =  $('.input-field.dirty').removeClass('dirty');
-				this.queryExpedition(expeditionID, {showOnLoadWarnings: false}) //suppress flagged expedition member warnings
-
-
-				// Hide the save button again since there aren't any edits
-				$('#save-expedition-button').ariaHide(true);
-				// but open the reports modal button since there's something to show
-				$('#open-reports-modal-button, #print-cache-tag-button, #edit-expedition-button, #delete-expedition-button').ariaHide(false);
-
-			}
-		}).fail((xhr, status, error) => {
-			showModal(`An unexpected error occurred while saving data to the database: ${error}. Make sure you're still connected to the NPS network and try again. Contact your database adminstrator if the problem persists.`, 'Unexpected error');
-			// roll back in-memory data
-		}).always(() => {
-		 	climberDB.hideLoadingIndicator();
-		});
-
+			}).fail((xhr, status, error) => {
+				showModal(`An unexpected error occurred while saving data to the database: ${error}. Make sure you're still connected to the NPS network and try again. Contact your database adminstrator if the problem persists.`, 'Unexpected error');
+				// roll back in-memory data
+			}).always(() => {
+			 	climberDB.hideLoadingIndicator();
+			});
+		})
 	}
 	
 


### PR DESCRIPTION
Added a flask endpoint to return the count of permits for a given year. A request to this endpoint is now sent when the user saves any edits _and_ there's an empty "permit number" field in any of the expedition member cards. This means that even expedition member cards that were created before this change will get updated if the user save any edits. 

The endpoint returns the just the number at the end of the permit_number in the form TKA-YY-####. It gets the `max()` value from the permit_number column for the given year and adds 1. This way, the new permit number that gets saved will always be unique.

The request to get the permit count is only sent if _any_ "permit number" fields are empty. Then when generating SQL for that expedition member, an if/else conditional determines whether or not the SQL should wait to be created until after the permit count request resolves. I defined a helper function within `.saveEdits()` to call the run the same SQL creation logic regardless 

Resolves issue #9 