### PR TITLE
show expedition ID in expedition card header

### DIFF
--- a/web/expeditions.html
+++ b/web/expeditions.html
@@ -139,6 +139,10 @@
 								</div>
 								<div class="expedition-data-header-content">							
 									<div class="result-details-summary-item col-6">
+										<div id="expedition-number-result-summary-item" class="collapse col">
+											<label class="result-details-summary-label">Expedition #</label>
+											<label class="result-details-summary-value"></label>
+										</div>
 										<div id="expedition-modified-by-result-summary-item" class="col">
 											<label class="result-details-summary-label">Modified by</label>
 											<label class="result-details-summary-value"></label>

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -3058,6 +3058,8 @@ class ClimberDBExpeditions extends ClimberDB {
 		$('#expedition-modified-time-result-summary-item .result-details-summary-value')
 			.text((new Date()).toLocaleDateString('en-US', {month: 'short', day: 'numeric', year: 'numeric'}));	
 		$('#expedition-n-members-result-summary-item').collapse('hide');
+		$('#expedition-number-result-summary-item').collapse('hide')
+			.find('.result-details-summary-value').text('');
 
 		$('.needs-filled-by-default').addClass('filled-by-default')
 	}
@@ -3261,6 +3263,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		for (const el of $('#expedition-data-container .input-field')) {
 			this.setInputFieldValue(el, expeditionData, {dbID: expeditionData.id, triggerChange: true});
 		}
+		$('#expedition-number-result-summary-item > .result-details-summary-value').text(expeditionData.id).closest('.collapse').collapse('show');
 		$('#expedition-modified-by-result-summary-item > .result-details-summary-value').text(expeditionData.expeditions_last_modified_by);
 		$('#expedition-modified-time-result-summary-item > .result-details-summary-value').text(expeditionData.expeditions_last_modified_time);
 


### PR DESCRIPTION
Now shown as .`result-details-summary-item`. For a new expedition, its hidden within a `.collapse` and shown whenever an expedition is loaded