### PR TITLE
use expected_expedition_size field in missing SUP/fee dashboard card

### DIFF
--- a/web/expeditions.html
+++ b/web/expeditions.html
@@ -210,9 +210,14 @@
 									</div>	
 								</div>
 								<div class="field-container-row">
-									<div class="field-container col-sm-6">
+									<div class="field-container col-sm-3">
 										<select id="input-special_group_type" class="input-field default filled-by-default needs-filled-by-default" name="special_group_type_code" data-table-name="expeditions" placeholder="Special group type" title="Special group type" type="text" autocomplete="__never"></select>
 										<label class="field-label" for="input-special_group_type">Special group type</label>
+										<span class="null-input-indicator">&lt; null &gt;</span>
+									</div>
+									<div class="field-container col-sm-3">
+										<input id="input-expected_expedition_size" class="input-field" name="expected_expedition_size" data-table-name="expeditions" title="Expected expedition size" type="number"> 
+										<label class="field-label" for="input-expected_expedition_size">Expected group size</label>
 										<span class="null-input-indicator">&lt; null &gt;</span>
 									</div>	
 									<div class="field-container checkbox-field-container col-6">


### PR DESCRIPTION
When an expedition leader applies for a permit, they indicate the number of people in the group. If any members haven't turned in any paperwork or paid their fee, there is now way to track their progress. To resolve this, I added a field, `expected_expedition_size`, to the expeditions table. If this field is filled in, the value will be used in the _Missing SUP or Climber Fee_ dashboard card to compare the number of people who have submitted paperwork and paid their fee with the number of expected members. If the number of actual expedition members entered exceeds the expected size entered, the actual number of expedition members will be used to calculate how many are missing either SUP or fee. The query behind that card got a but unwieldy, so I just created a view for it, especially since the SQL is completely static.