### PR TITLE
Enable fee updates from config

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -29,6 +29,10 @@ CREATE TABLE transaction_type_codes (
 	code INTEGER UNIQUE,
 	sort_order INTEGER,
 	is_credit BOOLEAN,
+	is_payment BOOLEAN,
+	permit_fee_multiplier INTEGER,
+	entrance_fee_multiplier	INTEGER,
+	youth_discount_multiplier	INTEGER,
 	default_fee MONEY
 );
 CREATE TABLE IF NOT EXISTS user_role_codes(id SERIAL PRIMARY KEY, name VARCHAR(50) UNIQUE, code INTEGER UNIQUE, sort_order INTEGER);
@@ -693,17 +697,17 @@ SELECT
 	sort_order,
 	is_payment, 
 	coalesce(
-		climbing_fee_multiplier * climbing_permit_fee + entrance_fee_multiplier * entrance_fee,
+		climbing_fee_multiplier * climbing_permit_fee + entrance_fee_multiplier * entrance_fee + youth_discount_multiplier * youth_discount_fee,
 		default_fee
 	) as default_fee
 FROM transaction_type_codes AS codes JOIN (
 	SELECT *  FROM crosstab(
 		'SELECT -1 AS id, property, value::MONEY
 		FROM config
-		WHERE property IN (''climbing_permit_fee'', ''entrance_fee'', ''cancellation_fee'')
+		WHERE property IN (''climbing_permit_fee'', ''entrance_fee'', ''cancellation_fee'', ''youth_discount_fee'')
 		ORDER BY property',
-		'SELECT property FROM config WHERE property IN (''climbing_permit_fee'', ''entrance_fee'', ''cancellation_fee'') ORDER BY property'
-	) AS _ (id INT, cancellation_fee MONEY, climbing_permit_fee MONEY, entrance_fee MONEY)
+		'SELECT property FROM config WHERE property IN (''climbing_permit_fee'', ''entrance_fee'', ''cancellation_fee'', ''youth_discount_fee'') ORDER BY property'
+	) AS _ (id INT, cancellation_fee MONEY, climbing_permit_fee MONEY, entrance_fee MONEY, youth_discount_fee MONEY)
 ) AS fees ON codes.id <> fees.id
 WHERE sort_order IS NOT NULL 
 ORDER BY sort_order;

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -4122,7 +4122,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				})
 		);
 		lookupDeferreds.push(
-			this.queryDB('SELECT code, default_fee, is_credit, is_payment FROM transaction_type_codes')
+			this.queryDB('SELECT code, default_fee, is_credit, is_payment FROM transaction_type_view')
 				.done(queryResultString => {
 					if (!this.queryReturnedError(queryResultString)) {
 						for (const row of $.parseJSON(queryResultString)) {
@@ -4144,12 +4144,12 @@ class ClimberDBExpeditions extends ClimberDB {
 			const params = this.parseURLQueryString();
 			// if the URL specifies a specific expedition (id) to load, do so
 			if ('id' in params) {
-					this.queryExpedition(params.id).done(() => {
-						// add to history buffer for keeping track of browser nav via back/forward buttons
-						this.historyBuffer.push(params.id);
-					});
-					window.history.replaceState({id: params.id, historyIndex: 0}, '', window.location.href);
-					$('#expedition-search-bar').data('current-value', params.id);
+				this.queryExpedition(params.id).done(() => {
+					// add to history buffer for keeping track of browser nav via back/forward buttons
+					this.historyBuffer.push(params.id);
+				});
+				window.history.replaceState({id: params.id, historyIndex: 0}, '', window.location.href);
+				$('#expedition-search-bar').data('current-value', params.id);
 			} 
 			// Otherwise, prepare the page for creating a new expedition
 			else if (this.checkEditPermissions()) {


### PR DESCRIPTION
Created a view to gather fees stored in the `config` table and calculate fees per transaction type on the fly. These fees include the climbing permit fee, the entrance fee, and the youth discount fee. I added 3 multiplier fields, one for each updatable fee, that have a value of -1, 0, or 1. The default fee calculated in the view for each transaction type is then the sum of each fee multiplied by its respective multiplier.