### PR TITLE
Add expedition file attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 web/packages/*
 web/exports/*
+web/attachments/*
 scratch.sql
 web/flask/assets/label_matrix_source.csv
 

--- a/create_db.sql
+++ b/create_db.sql
@@ -160,10 +160,10 @@ CREATE TABLE IF NOT EXISTS attachments (
 	mime_type varchar(50),
 	file_path VARCHAR(255), 
 	file_size_kb INTEGER,  
-	datetime_attached TIMESTAMP, 
-	attached_by VARCHAR(50), 
-	datetime_last_changed TIMESTAMP, 
-	last_changed_by VARCHAR(50)
+	entry_time TIMESTAMP, 
+	entered_by VARCHAR(50), 
+	last_modified_time TIMESTAMP, 
+	last_modified_by VARCHAR(50)
 )
 
 CREATE TABLE IF NOT EXISTS expedition_member_routes (
@@ -406,6 +406,10 @@ CREATE VIEW expedition_info_view AS
 		transactions.entered_by AS transactions_entered_by,
 		to_char(transactions.last_modified_time, 'Mon FMDD, YYYY') AS transactions_last_modified_time,
 		transactions.last_modified_by AS transactions_last_modified_by,
+		to_char(attachments.entry_time, 'Mon DD, YYYY'::text) AS attachments_entry_time,
+		attachments.entered_by AS attachments_entered_by,
+		to_char(attachments.last_modified_time, 'Mon FMDD, YYYY') AS attachments_last_modified_time,
+		attachments.last_modified_by AS attachments_last_modified_by,
 		expeditions.id AS expedition_id,
 		expeditions.expedition_name,
 		expeditions.date_confirmed,
@@ -465,6 +469,14 @@ CREATE VIEW expedition_info_view AS
 		transactions.transaction_notes,
 		transactions.transaction_date,
 		transactions.payment_method_code,
+		attachments.id AS attachment_id,
+		attachments.attachment_type_code,
+		attachments.date_received,
+		attachments.attachment_notes,
+		attachments.client_filename,
+		attachments.mime_type,
+		'attachments/' || split_part(attachments.file_path, '\', -1) AS file_path, --'
+		attachments.file_size_kb,
 		cmc_checkout.id AS cmc_checkout_id,
 		cmc_checkout.cmc_id,
 		cmc_checkout.issued_by,
@@ -481,6 +493,7 @@ CREATE VIEW expedition_info_view AS
 	LEFT JOIN briefings ON expeditions.id = briefings.expedition_id
 	LEFT JOIN expedition_member_routes ON expedition_members.id = expedition_member_routes.expedition_member_id
 	LEFT JOIN transactions ON expedition_members.id = transactions.expedition_member_id
+	LEFT JOIN attachments ON expedition_members.id = attachments.expedition_member_id
 	LEFT JOIN cmc_checkout ON expeditions.id = cmc_checkout.expedition_id
 	LEFT JOIN expedition_status_view ON expedition_status_view.expedition_id = expeditions.id
 	ORDER BY 
@@ -493,7 +506,8 @@ CREATE VIEW expedition_info_view AS
 		climbers.last_name, 
 		climbers.first_name, 
 		transactions.transaction_date, 
-		transactions.id;
+		transactions.id,
+		attachments.id;
 
 
 CREATE VIEW seven_day_rule_view AS 

--- a/create_db.sql
+++ b/create_db.sql
@@ -1,6 +1,7 @@
 CREATE DATABASE climbing_permits;
 
 --Create lookup tables
+CREATE TABLE IF NOT EXISTS attachment_type_codes(id SERIAL PRIMARY KEY, name VARCHAR(50) UNIQUE, code INTEGER UNIQUE, sort_order INTEGER);
 CREATE TABLE IF NOT EXISTS country_codes(id SERIAL PRIMARY KEY, short_name CHAR(2), name VARCHAR(50) UNIQUE, code INTEGER UNIQUE, sort_order INTEGER);
 CREATE TABLE IF NOT EXISTS cmc_status_codes(id SERIAL PRIMARY KEY, name VARCHAR(50) UNIQUE, code INTEGER UNIQUE, sort_order INTEGER);
 CREATE TABLE IF NOT EXISTS communication_device_type_codes (id SERIAL PRIMARY KEY, name VARCHAR(50) UNIQUE, code INTEGER UNIQUE, sort_order INTEGER);
@@ -32,7 +33,7 @@ CREATE TABLE transaction_type_codes (
 	is_payment BOOLEAN,
 	permit_fee_multiplier INTEGER,
 	entrance_fee_multiplier	INTEGER,
-	youth_discount_multiplier	INTEGER,
+	youth_discount_multiplier INTEGER,
 	default_fee MONEY
 );
 CREATE TABLE IF NOT EXISTS user_role_codes(id SERIAL PRIMARY KEY, name VARCHAR(50) UNIQUE, code INTEGER UNIQUE, sort_order INTEGER);
@@ -148,6 +149,22 @@ CREATE TABLE IF NOT EXISTS expedition_members (
 	last_modified_by VARCHAR(50),
 	last_modified_time TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS attachments (
+	id SERIAL PRIMARY KEY,
+	expedition_member_id INTEGER REFERENCES expedition_members(id) ON UPDATE CASCADE ON DELETE CASCADE,
+	attachment_type_code INTEGER REFERENCES attachment_type_codes(code) ON UPDATE CASCADE ON DELETE RESTRICT,
+	date_received DATE,
+	attachment_notes TEXT, 
+	client_filename VARCHAR(255),
+	mime_type varchar(50),
+	file_path VARCHAR(255), 
+	file_size_kb INTEGER,  
+	datetime_attached TIMESTAMP, 
+	attached_by VARCHAR(50), 
+	datetime_last_changed TIMESTAMP, 
+	last_changed_by VARCHAR(50)
+)
 
 CREATE TABLE IF NOT EXISTS expedition_member_routes (
 	id SERIAL PRIMARY KEY,

--- a/web/css/expeditions.css
+++ b/web/css/expeditions.css
@@ -88,6 +88,96 @@
 
 /* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^*/
 
+/* -------------------- attachment modal --------------*/
+.modal.lightbox-modal{
+    -webkit-transition: opacity .2s linear, none;
+    -moz-transition: opacity .2s linear, none;
+    -ms-transition: opacity .2s linear, none;
+    -o-transition: opacity .2s linear, none;
+    transition: opacity .2s linear, none;
+    z-index: 10000;
+}
+
+.modal.lightbox-modal.fade .modal-dialog {
+  /* turn off slide effect of the "fade" class*/
+  transition: none;
+  transform: none;
+
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+}
+
+.lightbox-modal .modal-content {
+  background-color: rgba(0,0,0,0);
+  border: none;
+  height: 80%;
+  /* display: flex; */
+  width: 80%;
+  justify-content: center;
+  align-items: center;
+  margin-top: -3rem; /*adjust for header height*/
+}
+
+.modal-img-body {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.modal-img-header {
+  padding: 0;
+}
+
+.modal-img-header .close,
+.modal-img-body-header .close {
+  color: white;
+}
+.modal-img-body-header .close img {
+  filter: invert(100%);/*makes black SVG imgs white*/
+}
+.modal-img-body {
+  height: 100%;
+  width: 100%;
+  padding: 0;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.modal-header-container {
+  width: 100%;
+  height: 3rem;
+  display: flex;
+  justify-content: center;
+}
+
+.modal-img-body-header {
+  width: 100%;
+  margin-bottom: 1rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.modal-img-body-header > .close {
+  color: white;
+  font-size: 2rem;
+}
+
+.modal-img {
+  width: 100%;
+  height: calc(100% - 20px - 1rem);
+  object-fit: contain;
+}
+/* ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^*/
+
 /*----- expedition search bar dropdowns ------*/
 .fuzzy-search-bar-drawer {
 	width: 100%;
@@ -516,11 +606,49 @@
 	width: 100%;
 	margin-top: 25px;
 }
+
+.file-input-label {
+	width: 150px;
+}
+.preview-attachment-button {
+	min-width: 0;
+	width: 100px;
+}
+.attachment-progress-bar-container {
+	height: 100%;
+	display: flex;
+	align-items: center;
+}
+.attachment-progress-bar {
+	width: 100%;
+	height: .75rem;
+	border-radius: 1rem;
+	background-color: #D4D4D4;
+	overflow: hidden;
+}
+.attachment-progress-indicator {
+	background-color: var(--ui-secondary-highlight-color);
+	width: 0%;
+	height: 100%;
+	border-top-right-radius: 0px;
+	border-bottom-right-radius: 0px;
+	text-align: right;
+	text-indent: 5px;
+	font-size: .7rem;
+	color: white;
+	line-height: 100%;
+	transition: all 0.1s linear;
+}
+
+.preview-attachment-button-column {
+	width: 120px;
+}
 .transactions-container-body,
 .transactions-header-container {
 	width: 100%;
 }
-.transactions-header-container {
+.transactions-header-container,
+.attachments-header-container {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -541,10 +669,13 @@
 }
 .expedition-modal .transaction-type-column,
 .expedition-modal .payment-method-column,
-.expedition-modal .transaction-date-column {
+.expedition-modal .transaction-date-column, 
+.expedition-modal .document-type-column, 
+.expedition-modal .attachment-received-column, 
+.expedition-modal .file-name-column {
 	max-width: 200px;
 }
-.transaction-entry-metadata-column {
+.data-list-metadata-column {
 	width: 100px;
 }
 .route-member-name-column {

--- a/web/css/expeditions.css
+++ b/web/css/expeditions.css
@@ -641,8 +641,23 @@
 }
 
 .preview-attachment-button-column {
-	width: 120px;
+	width: 150px;
 }
+.preview-attachment-button-column .show-attachment-details-button {
+	font-weight: bold;
+}
+/*set the button text depending on whether the card is being shown as a modal or not*/
+.preview-attachment-button-column .show-attachment-details-button::before {
+	content: 'More...';
+}
+.expedition-modal .preview-attachment-button-column .show-attachment-details-button::before {
+	content: 'Less...';
+}
+/*match the botton margin of uneditable inputs*/
+.uneditable .show-attachment-details-button {
+	margin-bottom: 0.75rem;
+}
+
 .transactions-container-body,
 .transactions-header-container {
 	width: 100%;
@@ -679,7 +694,7 @@
 	max-width: 250px;
 }
 .expedition-modal .preview-attachment-button-column {
-	max-width: 100px;
+	max-width: 150px;
 }
 .data-list-metadata-column {
 	width: 100px;

--- a/web/css/expeditions.css
+++ b/web/css/expeditions.css
@@ -672,8 +672,14 @@
 .expedition-modal .transaction-date-column, 
 .expedition-modal .document-type-column, 
 .expedition-modal .attachment-received-column, 
-.expedition-modal .file-name-column {
+.expedition-modal .attachment-type-field {
 	max-width: 200px;
+}
+.expedition-modal .file-name-column {
+	max-width: 250px;
+}
+.expedition-modal .preview-attachment-button-column {
+	max-width: 100px;
 }
 .data-list-metadata-column {
 	width: 100px;
@@ -712,12 +718,14 @@
 }
 .transactions-tab-pane .refund-post-item .input-field,
 .transactions-tab-pane .refund-post-item .unit-symbol,
-.transactions-tab-pane .entry-metadata-field {
+.transactions-tab-pane .entry-metadata-field,
+.attachments-tab-pane .entry-metadata-field {
 	color: hsl(0, 0%, 40%);
 	font-style: italic;
 }
 .transactions-tab-pane .refund-post-item .input-field,
-.transactions-tab-pane .entry-metadata-field {
+.transactions-tab-pane .entry-metadata-field,
+.attachments-tab-pane .entry-metadata-field {
 	pointer-events: none;
 	border-bottom: none;
 /*	position: relative; /*allows hiding calendar-date-picker*/

--- a/web/expeditions.html
+++ b/web/expeditions.html
@@ -579,10 +579,15 @@
 																		<span id="text-last_modified_time" class="input-field entry-metadata-field last-modified-time-field"></span>
 																	</div>
 																	<div class="col d-flex preview-attachment-button-column">
+																		<button class="text-only-button fw-bold expand-card-button show-attachment-details-button show-on-parent-hover" role="button" type="button" title="Show details" aria-hidden="true"></button>
+																		<button class="icon-button preview-attachment-button show-on-parent-hover" role="button" type="button" title="Open attachment" aria-hidden="true">
+																			<i class="fas fa-file-pdf fa-lg"></i>
+																			<label class="icon-button-label">open</label>
+																		</button>
 																		<button class="icon-button delete-button delete-attchment-button show-on-parent-hover" title="Delete attachment">
 																			<i class="fas fa-trash fa-lg"></i>
+																			<label class="icon-button-label">delete</label>
 																		</button>
-																		<button class="text-only-button fw-bold preview-attachment-button show-on-parent-hover hidden" role="button" type="button" title="Open attachment" aria-hidden="true">Open</button> 
 																	</div>
 																</li>
 															</ul>

--- a/web/expeditions.html
+++ b/web/expeditions.html
@@ -309,6 +309,9 @@
 													<li class="nav-item show-transaction-tab-button" role="presentation">
 														<a id="transactions-tab-button" class="nav-link" data-toggle="tab" href="#transactions-tab-pane" type="button" role="tab" aria-controls="transactions-tab-pane" aria-selected="false" title="Show expedition member transactions">Transactions</a>
 													</li>
+													<li class="nav-item" role="presentation">
+														<a id="attachments-tab-button" class="nav-link" data-toggle="tab" href="#attachments-tab-pane" type="button" role="tab" aria-controls="attachments-tab-pane" aria-selected="false" title="Show expedition member attachments">Attachments</a>
+													</li>
 												</ul>
 												<div class="tab-content expedition-member-tab-content">
 													<div id="expedition-info-tab-pane" class="tab-pane expedition-info-tab-pane fade show active" role="tabpanel" aria-labelledby="expedition-info-tab-button">
@@ -478,8 +481,8 @@
 																<label class="data-list-col data-list-header-label col col-13-percent transaction-value-column">Value</label>
 																<label class="data-list-col data-list-header-label col-2 transaction-date-column">Date</label>
 																<label class="data-list-col data-list-header-label col transaction-notes-column">Transaction notes</label>
-																<label class="data-list-col data-list-header-label modal-only transaction-entry-metadata-column hidden">Last edit by</label>
-																<label class="data-list-col data-list-header-label modal-only transaction-entry-metadata-column hidden">Last edit date</label>
+																<label class="data-list-col data-list-header-label modal-only data-list-metadata-column hidden">Last edit by</label>
+																<label class="data-list-col data-list-header-label modal-only data-list-metadata-column hidden">Last edit date</label>
 															</div>
 															<ul id="transactions-list" class="data-list">
 																<li class="data-list-item show-children-on-hover cloneable hidden">
@@ -508,10 +511,10 @@
 																			</button>
 																		</div>
 																	</div>
-																	<div class="transaction-entry-metadata-column modal-only hidden" aria-hidden="true">
+																	<div class="data-list-metadata-column modal-only hidden" aria-hidden="true">
 																		<span id="text-last_modified_by" class="input-field entry-metadata-field last-modified-by-field"></span>
 																	</div>
-																	<div class="transaction-entry-metadata-column modal-only hidden" aria-hidden="true">
+																	<div class="data-list-metadata-column modal-only hidden" aria-hidden="true">
 																		<span id="text-last_modified_time" class="input-field entry-metadata-field last-modified-time-field"></span>
 																	</div>
 																</li>
@@ -524,11 +527,68 @@
 																</label>
 																<label class="data-list-col data-list-header-label col-2 transaction-date-column"></label>
 																<label class="data-list-col data-list-header-label col transaction-notes-column"></label>
-																<label class="data-list-col data-list-header-label transaction-entry-metadata-column modal-only hidden"></label>
-																<label class="data-list-col data-list-header-label transaction-entry-metadata-column modal-only hidden"></label>
+																<label class="data-list-col data-list-header-label data-list-metadata-column modal-only hidden"></label>
+																<label class="data-list-col data-list-header-label data-list-metadata-column modal-only hidden"></label>
 															</div>
 														</div>
 													</div>
+													<div id="attachments-tab-pane" class="tab-pane attachments-tab-pane fade" role="tabpanel" aria-labelledby="attachments-tab-button">
+														<div class="attachments-header-container">
+															<h5 class="expedition-data-sub-header"></h5>
+															<button class="generic-button add-data-button add-attachment-button" role="button" type="button" title="Add attchment">Add attchment</button>
+														</div>
+														<div class="attachments-container-body">
+															<div class="data-list-item data-list-item-header">
+																<label id="document-type-attachment-header" class="data-list-col data-list-header-label col-3 document-type-column">Document type</label>
+																<label id="date-received-attachment-header" class="data-list-col data-list-header-label col-2 attachment-received-column">Date received</label>
+																<label id="file-name-attachment-header" class="data-list-col data-list-header-label col-4 file-name-column">File name</label>
+																<label id="attachment-notes-attachment-header" class="data-list-col data-list-header-label col modal-only attachment-notes-column hidden">Attachment notes</label>
+																<label id="last-modified-by-attachment-header" class="data-list-col data-list-header-label modal-only data-list-metadata-column hidden">Last edit by</label>
+																<label id="last-modified-date-attachment-header" class="data-list-col data-list-header-label modal-only data-list-metadata-column hidden">Last edit date</label>
+																<label class="data-list-col data-list-header-label col preview-attachment-button-column"></label>
+															</div>
+															<ul id="attachments-list" class="data-list">
+																<li class="data-list-item show-children-on-hover cloneable hidden" aria-hidden="true">
+																	<div class="col-3 d-flex document-type-column">
+																		<select id="input-attachment_type" class="input-field attachment-type-field" name="attachment_type_code" data-table-name="attachments" placeholder="Attachment type" title="Attachment type" aria-labelledby="document-type-attachment-header" required=""></select>
+																		<span class="required-indicator">*</span>
+																	</div>
+																	<div class="col-2 attachment-received-column">
+																		<input id="input-date_received" class="input-field" name="date_received" type="date" data-table-name="attachments"title="Payment method" aria-labelledby="date-received-attachment-header" required="">
+																		<span class="required-indicator">*</span>
+																	</div>
+																	<div class="col col-4 file-name-column">
+																		<div class="d-flex justify-content-center">
+																			<label class="generic-button file-input-label" for="attachment-upload">Select file</label>
+																			<input id="attachment-upload" class="input-field hidden attachment-input" type="file" accept="image/*, .pdf" name="file_upload" aria-hidden="true" required="">
+																		</div>
+																		<div class="attachment-progress-bar-container hidden" aria-hidden="true">
+																			<div class="attachment-progress-bar">
+																				<div class="attachment-progress-indicator"></div>
+																			</div>
+																		</div>
+																		<input id="input-client_filename" class="input-field file-name-field hidden" name="client_filename" data-table-name="attachments" title="File name" aria-hidden="true" aria-labelledby="file-name-attachment-header"> 
+																	</div>
+																	<div class="col d-flex attachment-notes-column modal-only hidden">
+																		<input id="input-attachment_notes" class="input-field" name="attachment_notes" type="text" data-table-name="attachments" title="Transaction type"> 
+																	</div>
+																	<div class="data-list-metadata-column modal-only hidden" aria-hidden="true">
+																		<span id="text-last_modified_by" class="input-field entry-metadata-field last-modified-by-field"></span>
+																	</div>
+																	<div class="data-list-metadata-column modal-only hidden" aria-hidden="true">
+																		<span id="text-last_modified_time" class="input-field entry-metadata-field last-modified-time-field"></span>
+																	</div>
+																	<div class="col d-flex preview-attachment-button-column">
+																		<button class="icon-button delete-button delete-attchment-button show-on-parent-hover" title="Delete attachment">
+																			<i class="fas fa-trash fa-lg"></i>
+																		</button>
+																		<button class="text-only-button fw-bold preview-attachment-button show-on-parent-hover hidden" role="button" type="button" title="Open attachment" aria-hidden="true">Open</button> 
+																	</div>
+																</li>
+															</ul>
+														</div>
+													</div>
+													
 												</div>
 
 											</div>
@@ -786,6 +846,25 @@
 	
 	<!-- modal for selecting climbers to add to expeditions -->
 	<div id="add-climber-form-modal-container" class="climber-form-modal-container uneditable hidden" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true"></div>
+
+	<!-- attachment viewer modal -->
+	<div class="modal fade lightbox-modal" id="attachment-modal" tabindex="-1" role="dialog" aria-hidden="true">
+	  <div class="modal-dialog" role="document" data-dismiss="modal">
+	    <div class="modal-content" data-dismiss="modal">
+	      <div class="modal-body modal-img-body" >
+	      	<div class="modal-header-container" data-dismiss="modal">
+		      	<div class="modal-img-body-header">
+			        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+			        	<span aria-hidden="true">&times;</span>
+			        </button>
+		      	</div>
+		    </div>
+			<img class="modal-img hidden" src="#" id="modal-img-preview" alt="preview of uploaded image">
+			<object type="application/pdf" data="" width="100%" height="100%">Sorry, your browser doesn't support viewing a PDF</object>
+	      </div>
+	    </div>
+	  </div>
+	</div>
 
 	<script src="packages/bootstrap/bootstrap.min.js"></script>
 	<script src="js/climberdb.js"></script>

--- a/web/expeditions.html
+++ b/web/expeditions.html
@@ -560,7 +560,7 @@
 																	<div class="col col-4 file-name-column">
 																		<div class="d-flex justify-content-center">
 																			<label class="generic-button file-input-label" for="attachment-upload">Select file</label>
-																			<input id="attachment-upload" class="input-field hidden attachment-input" type="file" accept="image/*, .pdf" name="file_upload" aria-hidden="true" required="">
+																			<input id="attachment-upload" class="hidden attachment-input" type="file" accept="image/*, .pdf" name="file_upload" aria-hidden="true" required="">
 																		</div>
 																		<div class="attachment-progress-bar-container hidden" aria-hidden="true">
 																			<div class="attachment-progress-bar">

--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -633,6 +633,16 @@ def save_attachment():
 	return {'failed_files': failed_files, 'attachment_ids': attachment_ids}
 
 
+@app.route('/flask/attachments/delete_expedition_member_file', methods=['POST'])
+def delete_attachment():
+	filename = os.path.basename(request.form['file_path'])
+	file_path = os.path.join(get_content_dir('attachments'), filename)
+	if (os.path.isfile(file_path)):
+		os.remove(file_path) # requires modify permissions for server AD user
+		return 'true'
+	else:
+		return 'false'
+	
 
 #---------------- DB I/O ---------------------#
 

--- a/web/js/climberdb.js
+++ b/web/js/climberdb.js
@@ -631,6 +631,7 @@ class ClimberDB {
 		const $cloneable = $ul.find('li.cloneable');
 		const $newItem = $cloneable.clone(true)//withDataAndEvents=true
 			.removeClass('cloneable hidden')
+			.attr('aria-hidden', false);
 
 		var itemIndex = $ul.find('li:not(.cloneable)').length;
 		var newItemID = `${$ul.attr('id')}-${itemIndex}`;
@@ -653,6 +654,13 @@ class ClimberDB {
 			if ($el.data('dependent-target')) 
 				$el.data('dependent-target', `${$el.data('dependent-target')}-${dbID || itemIndex}`);
 			if (!isNaN(dbID)) $el.attr('data-table-id', dbID);
+		}
+
+		for (const el of $newItem.find('label.generic-button')) {
+			const $el = $(el);
+			if ($el.prop('for')) {
+				$el.prop('for', `${$el.prop('for')}-${dbID || itemIndex}`);
+			}
 		}
 
 		return $newItem.addClass(newItemClass).insertBefore($cloneable);
@@ -714,7 +722,7 @@ class ClimberDB {
 		// Add to the accordion
 		$newCard.addClass(newCardClass).appendTo($accordion).fadeIn();
 
-		for (const el of $('#' + newCardID).find('.input-field')) {
+		for (const el of $newCard.find('.input-field')) {
 			const $el = $(el);
 			const newID = `${el.id}-${cardIndex}`;
 			const dataTable = $el.data('table-name');
@@ -733,6 +741,13 @@ class ClimberDB {
 			if ($el.is('select')) {
 				$el.val('').addClass('default');
 			}
+		}
+
+		for (const el of $newCard.find('label.generic-button')) {
+			const $el = $(el);
+			if ($el.prop('for')) {
+				$el.prop('for', `${$el.prop('for')}-${cardIndex}`);
+			}			
 		}
 
 		// if the accordion's data-table-name attribute is in update IDs, 

--- a/web/js/climberdb.js
+++ b/web/js/climberdb.js
@@ -1055,7 +1055,7 @@ class ClimberDB {
 
 
 	pythonReturnedError(resultString) {
-
+		resultString = String(resultString); // force as string in case it's something else
 		return resultString.startsWith('ERROR: Internal Server Error') ?
 		   resultString.match(/[A-Z]+[a-zA-Z]*Error: .*/)[0].trim() :
 		   false;

--- a/web/js/climberdb.js
+++ b/web/js/climberdb.js
@@ -648,7 +648,7 @@ class ClimberDB {
 		if (parentDBID !== null) $newItem.data('parent-table-id', parentDBID);
 		if (dbID !== null) $newItem.attr('data-table-id', dbID);
 
-		for (const el of $newItem.find('.input-field')) {
+		for (const el of $newItem.find('.input-field, .attachment-input')) {
 			el.id = `${el.id}-${dbID || itemIndex}`;
 			const $el = $(el);
 			if ($el.data('dependent-target')) 
@@ -722,7 +722,7 @@ class ClimberDB {
 		// Add to the accordion
 		$newCard.addClass(newCardClass).appendTo($accordion).fadeIn();
 
-		for (const el of $newCard.find('.input-field')) {
+		for (const el of $newCard.find('.input-field, .attachment-input')) {
 			const $el = $(el);
 			const newID = `${el.id}-${cardIndex}`;
 			const dataTable = $el.data('table-name');

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -341,6 +341,10 @@ class ClimberDBExpeditions extends ClimberDB {
 			$newItem.attr('data-parent-table-id', $card.data('table-id'));
 		});
 
+		$(document).on('click', '.delete-attchment-button', e => {
+			this.onDeleteAttachmentButtonClick(e);
+		})
+
 		// When the leader input checkbox changes, set the transparent class appropriately
 		$(document).on('change', '.leader-checkbox-container .input-checkbox', e => {
 			const $checkbox = $(e.target).closest('.input-checkbox');
@@ -3971,6 +3975,8 @@ class ClimberDBExpeditions extends ClimberDB {
 				};
 				
 				const $listItem = $barContainer.closest('.data-list-item');
+				
+				// hide the select-file button (label)
 				$listItem.find('.file-input-label')
 					.ariaHide(true);
 				
@@ -4076,6 +4082,35 @@ class ClimberDBExpeditions extends ClimberDB {
 		$attachmentModal.modal();
 		
 	}
+
+
+	/*
+	Attachment delete button handler
+	*/
+	onDeleteAttachmentButtonClick(e) {
+		const $li = $(e.target).closest('.data-list-item');
+		if ($li.is('.new-list-item')) {
+			this.deleteListItem($li);
+		} else {
+			
+			const onConfirmClickHandler = () => {
+				$('.modal-button.confirm-delete').click( () => {
+					const dbID = $li.data('table-id');
+					this.deleteListItem($li, 'attachments', dbID);
+				})
+			}
+			const message = 
+				'Are you sure you want to delete this Attachment? This action is permanent' + 
+				' and cannot be undone.';
+			const title = 'Delete Attachment?';
+			const footerButtons = 
+				'<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">Cancel</button>' +
+				'<button class="generic-button modal-button danger-button close-modal confirm-delete" data-dismiss="modal">Delete</button>';
+			showModal(message, title, 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});	
+		}
+
+	}
+
 
 	onAddRouteButtonClick(e) {
 		if (!$('#expedition-members-accordion .card:not(.cloneable)').length) {

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -419,6 +419,12 @@ class ClimberDBExpeditions extends ClimberDB {
 			this.onAttachmentInputChange(e);
 		});
 
+		$(document).on('click', '.show-attachment-details-button', e => {
+			const $wrapper = $(e.target).closest('.expedition-data-wrapper')
+			const $expandButton = $wrapper.find('.expedition-data-header-container .expand-card-button')
+			this.setExpandCardButtonLabelText($expandButton, $wrapper.is('.expedition-modal'))
+		});
+
 		$(document).on('click', '.preview-attachment-button', e => {
 			this.onPreviewAttachmentButtonClick(e)
 		})
@@ -962,6 +968,21 @@ class ClimberDBExpeditions extends ClimberDB {
 	}
 
 
+	
+	/*
+	Helper function to set the .expand-card-button label and the associated icon to 
+	either 'minimize' or 'maximize'
+	*/
+	setExpandCardButtonLabelText($button, shouldExpand) {
+		// Font awesome classes don't neatly override each other by last-in-wins so toggle each class separately
+		$button.find('.expand-card-icon')
+			.toggleClass('fa-expand-alt', !shouldExpand)
+			.toggleClass('fa-compress-alt', shouldExpand);
+
+		$button.find('.icon-button-label').text(shouldExpand ? 'minimize' : 'maximize');
+	}
+
+
 	/*
 	Expand a card to take the whole screen as a modal when the expand button is clicked
 	*/
@@ -982,12 +1003,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		// Show any elements that only appear in modal view
 		$wrapper.find('.modal-only').ariaHide(!shouldExpand);
 
-		// Font awesome classes don't neatly override each other by last-in-wins so toggle each class separately
-		$button.find('.expand-card-icon')
-			.toggleClass('fa-expand-alt', !shouldExpand)
-			.toggleClass('fa-compress-alt', shouldExpand);
-
-		$button.find('.icon-button-label').text(shouldExpand ? 'minimize' : 'maximize');
+		this.setExpandCardButtonLabelText($button, shouldExpand)
 	}
 
 

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -1416,10 +1416,6 @@ class ClimberDBExpeditions extends ClimberDB {
 
 		// collect info about inserts so attributes can be changes such that future edits are treated as updates
 		var inserts = []; //{container: container, tableName: tableName}
-
-
-
-
 		// get expedition table edits
 		var expeditionValues = [];
 		var expeditionFields = []; 
@@ -3957,7 +3953,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		
 		if (sourceInput.files && file) {
 			var reader = new FileReader();
-			const fileName = file.name;
+			const filename = file.name;
 
 			reader.onprogress = function(e) {
 				// Show progress
@@ -3972,7 +3968,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			reader.onerror = function(e) {
 				// Hide preview and progress bar and notify the user
 				$progressBar.ariaHide();
-				showModal(`The file '${fileName}' failed to upload correctly. Make sure your internet connection is consistent and try again.`, 'Upload failed');
+				showModal(`The file '${filename}' failed to upload correctly. Make sure your internet connection is consistent and try again.`, 'Upload failed');
 			}
 
 			// Get local reference to .attachments attribute because `this` refers to the FieReader 
@@ -4001,7 +3997,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				
 				// Show the filename field and the preview button
 				$listItem.find('.file-name-field')
-					.val(fileName)
+					.val(filename)
 					.ariaHide(false);
 				$listItem.find('.preview-attachment-button')
 					.ariaHide(false);
@@ -4022,11 +4018,22 @@ class ClimberDBExpeditions extends ClimberDB {
 		const el = e.target; 
 		const $input = $(el);
 
-		// If the user cancels, it resets the input files attribute to null 
-		//	which is dumb. Reset it to the previous file and exit
-		if (el.files.length === 0) {
-			el.files = _this.attachmentFiles[el.id];
-			return
+		// If the user cancels, just exit
+		if (el.files.length === 0) return;
+
+		// Make sure the filename doesn't already exist. This is only necessary because 
+		//	when saving multiple attachments, the file and associated info is related 
+		//	by the filename. It's also probably just good practice to enforce
+		const existingfilenames = $('.file-name-field')
+			.map((_, el) => el.value)
+			.get() // get as JS array, not jQuery
+			.filter(v => v) // drop null values
+		const filename = el.files[0].name;
+		if (existingfilenames.includes(filename)) {
+			showModal(`An attachment with the filename <strong>${filename}</strong> already` + 
+				' exists. All attachments for an expedition must have unique filenames.' + 
+				' Please rename the file and upload it again.', 'Duplicate filename')
+			return;
 		}
 
 		$input.siblings('.file-input-label').ariaHide(true);
@@ -4036,7 +4043,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				.find('.attachment-progress-indicator');
 
 		$input.siblings('.file-name-field')
-			.val(el.files[0].name)
+			.val(filename)
 			.change();
 		
 		this.readAttachment(el, $progressIndicator);

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -4288,6 +4288,22 @@ class ClimberDBExpeditions extends ClimberDB {
 			const onConfirmClickHandler = () => {
 				$('.modal-button.confirm-delete').click( () => {
 					const dbID = $li.data('table-id');
+					
+					// try to delete the file from the server
+					$.post({
+						url: 'flask/attachments/delete_expedition_member_file',
+						data: {
+							file_path: this.attachments[$li.find('input[type=file]').attr('id')].url
+						}
+					}).done(response => {
+						if (this.pythonReturnedError(response)) {
+							console.log(response)
+						}
+					}).fail((xhr, status, error) => {
+						conole.log(error)
+					})
+
+					// Delete the DB record regardless of whether deleting the file succeeded
 					this.deleteListItem($li, 'attachments', dbID);
 				})
 			}


### PR DESCRIPTION
These changes constitute the ability to add PDF or image attachments for an expedition member. Attachments can be viewed in the browser in a preview modal. Attachment details are stored in the database, but attachment files are actually stored on the server in an `attachments` directory. Attachments can only be added to existing expedition members, not new ones that have yet to be saved to the database. This is so that saving the file and the database record(s) can happen with a single call to the server.