### PR TITLE
fix auto calculation of age in climber_info_view

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -298,7 +298,10 @@ CREATE VIEW climber_info_view AS
 	    climbers.country_code,
 	    climbers.postal_code,
 	    climbers.dob,
-	    COALESCE(climbers.age, (now()::date - climbers.dob) / 365) AS age,
+	    CASE  
+	    	WHEN climbers.dob IS NULL AND climbers.age IS NOT NULL THEN extract(years FROM age(now(), climbers.entry_time)) + climbers.age  
+	    	ELSE extract(years FROM age(now(), climbers.dob)) 
+	    END AS age,
 	    climbers.email_address,
 	    climbers.phone,
 	    climbers.sex_code,


### PR DESCRIPTION
Age field in `climber_info_view` is now estimated using the date the climber record was first created when the d.o.b. is null. This allows the age to autoincrement rather than remaining static. This isn't a perfect solution because if the age is corrected after the climber record was first created, the estimation based on `entry_time` will be incorrect. The only way to remedy this would be to create an `age_last_modified_time` field, but that's not worth the effort