### PR TITLE
Add intl. state province field

### DIFF
--- a/web/css/climbers.css
+++ b/web/css/climbers.css
@@ -174,9 +174,9 @@
 #add-new-climber-button {
 	position: absolute;
 }
-
 .editing-buttons-container {
 	font-size: 2rem;
+	display: flex;
 }
 .query-result-edit-button-container > .query-result-edit-button,
 .editing-buttons-container > .query-result-edit-button {
@@ -188,6 +188,9 @@
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: center;
+}
+.query-result-edit-button > .icon-button-label {
+	margin-top: unset;
 }
 .query-result-edit-button-container > .query-result-edit-button:hover {
 	color: #f28100;

--- a/web/css/climbers.css
+++ b/web/css/climbers.css
@@ -184,6 +184,10 @@
 	color: #219ebc;/*#e77a00;*/
 	transition: .3s all;
 	pointer-events: all;
+	height: 50px;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
 }
 .query-result-edit-button-container > .query-result-edit-button:hover {
 	color: #f28100;

--- a/web/js/climbers.js
+++ b/web/js/climbers.js
@@ -17,6 +17,10 @@ class ClimberForm {
 				<div class="climber-form-content">
 					<div class="header-button-container">
 						<div class="editing-buttons-container">
+							<button id="edit-button" class="query-result-edit-button icon-button toggle-editing-button" type="button" aria-label="Edit selected climber" title="Edit climber">
+								<i class="fas fa-edit"></i>
+								<label class="icon-button-label">edit</label>
+							</button>
 							<button id="save-button" class="query-result-edit-button icon-button save-edits-button hidden" type="button" aria-label="Save edits" title="Save edits">
 								<i class="fas fa-save"></i>
 								<label class="icon-button-label">save</label>
@@ -24,10 +28,6 @@ class ClimberForm {
 							<button id="delete-button" class="query-result-edit-button icon-button delete-climber-button hidden" type="button" aria-label="Delete selected climber" title="Delete climber">
 								<i class="fas fa-trash"></i>
 								<label class="icon-button-label">delete</label>
-							</button>
-							<button id="edit-button" class="query-result-edit-button icon-button toggle-editing-button" type="button" aria-label="Edit selected climber" title="Edit climber">
-								<i class="fas fa-edit"></i>
-								<label class="icon-button-label">edit</label>
 							</button>
 						</div>
 						<div class="close-button-container">

--- a/web/js/climbers.js
+++ b/web/js/climbers.js
@@ -171,9 +171,14 @@ class ClimberForm {
 										<span class="null-input-indicator">&lt; null &gt;</span>
 									</div>	
 									<div class="field-container col-sm-6 collapse">
-										<select id="input-state" class="input-field default" name="state_code" data-table-name="climbers" placeholder="State" title="State" type="text" autocomplete="__never" required="" data-dependent-target="#input-country" data-dependent-value=236></select>
+										<select id="input-state" class="input-field default" name="state_code" data-table-name="climbers" placeholder="State/province" title="State" type="text" autocomplete="__never" required="" data-dependent-target="#input-country" data-dependent-value="236,40"></select>
 										<span class="required-indicator">*</span>
-										<label class="field-label" for="input-state">State</label>
+										<label class="field-label" for="input-state">State/province</label>
+										<span class="null-input-indicator">&lt; null &gt;</span>
+									</div>		
+									<div class="field-container col-sm-6 collapse">
+										<input id="input-other_state_name" class="input-field" type="text" name="other_state_name" data-table-name="climbers" placeholder="State/province" title="State" type="text" autocomplete="__never" data-dependent-target="#input-country" data-dependent-value="!236,40">
+										<label class="field-label" for="input-other_state_name">State/province</label>
 										<span class="null-input-indicator">&lt; null &gt;</span>
 									</div>	
 								</div>
@@ -407,8 +412,13 @@ class ClimberForm {
 														<span class="null-input-indicator">&lt; null &gt;</span>
 													</div>	
 													<div class="field-container col-sm-6 collapse">
-														<select id="input-state_contact" class="input-field default" name="state_code" data-table-name="emergency_contacts" placeholder="State" title="State" type="text" autocomplete="__never" data-dependent-target="#input-country_contact" data-dependent-value=236></select>
-														<label class="field-label" for="input-state">State</label>
+														<select id="input-state_contact" class="input-field default" name="state_code" data-table-name="emergency_contacts" placeholder="State/province" title="State/province" data-dependent-target="#input-country_contact" data-dependent-value="236,40"></select>
+														<label class="field-label" for="input-state_contact">State</label>
+														<span class="null-input-indicator">&lt; null &gt;</span>
+													</div>	
+													<div class="field-container col-sm-6 collapse">
+														<input id="input-other_state_contact" class="input-field default" name="other_state_name" data-table-name="emergency_contacts" placeholder="State/province" title="State" type="text" autocomplete="__never" data-dependent-target="#input-country_contact" data-dependent-value="!236,40">
+														<label class="field-label" for="input-other_state_contact">State/province</label>
 														<span class="null-input-indicator">&lt; null &gt;</span>
 													</div>	
 												</div>
@@ -695,11 +705,17 @@ class ClimberForm {
 						.val(details['place name'])
 						.change();
 					
-					// If the country is the US, update the state
-					if (countryAbbreviation == 'US') {
+					// If the country is the US or Canada, update the state
+					if (['US', 'CA'].includes(countryAbbreviation)) {
 						const stateCode = this.stateCodes[details['state abbreviation']] || '';
 						$container.find('.input-field[name=state_code]')
 							.val(stateCode)
+							.change();
+					// If it's somewhere else, make sure 'state' is in the response JSON. If so,
+					//	set the international state name field
+					} else if ('state' in details) {
+						$container.find('.input-field[name=other_state_name]')
+							.val(details.state)
 							.change();
 					}
 				}


### PR DESCRIPTION
I apparently already had a field in the DB for `other_state_name` for this purpose, I just added the field to the climber profile form and updated the `data-dependent-value` property of the existing `state_code` field so the US/CA state field and the `other_state_name` field will toggle appropriately based on the country selected. I also updated the change event handler for postal code fields so it'll fill the `other_state_name` if the selected country is not US/CA.

I also fixed an oversight with the addition of `.icon-button-labels` to the edit buttons.