### PR TITLE
set associated checkbox when attachment added and vice versa

### DIFF
--- a/web/expeditions.html
+++ b/web/expeditions.html
@@ -282,14 +282,14 @@
 												</div>
 												<div class="col pl-0 card-header-content-container card-header-field-container">
 													<label class="checkmark-container">
-														<input id="input-application_complete" class="input-field input-checkbox" type="checkbox" name="application_complete" data-table-name="expedition_members" title="Permit application complete?">
+														<input id="input-application_complete" class="input-field input-checkbox file-submission-checkbox" type="checkbox" name="application_complete" data-table-name="expedition_members" title="Permit application complete?">
 														<span class="checkmark data-input-checkmark"></span>
 													</label>
 													<label class="field-label checkbox-label" for="input-application_complete">SUP app.</label>
 												</div>
 												<div class="col px-0 card-header-content-container card-header-field-container">
 													<label class="checkmark-container">
-														<input id="input-psar_complete" class="input-field input-checkbox" type="checkbox" name="psar_complete" data-table-name="expedition_members" title="PSAR form complete?">
+														<input id="input-psar_complete" class="input-field input-checkbox file-submission-checkbox" type="checkbox" name="psar_complete" data-table-name="expedition_members" title="PSAR form complete?">
 														<span class="checkmark data-input-checkmark"></span>
 													</label>
 													<label class="field-label checkbox-label" for="input-psar_complete">PSAR</label>
@@ -315,7 +315,7 @@
 														<a id="transactions-tab-button" class="nav-link" data-toggle="tab" href="#transactions-tab-pane" type="button" role="tab" aria-controls="transactions-tab-pane" aria-selected="false" title="Show expedition member transactions">Transactions</a>
 													</li>
 													<li class="nav-item" role="presentation">
-														<a id="attachments-tab-button" class="nav-link" data-toggle="tab" href="#attachments-tab-pane" type="button" role="tab" aria-controls="attachments-tab-pane" aria-selected="false" title="Show expedition member attachments">Attachments</a>
+														<a id="attachments-tab-button" class="nav-link show-attachment-tab-button" data-toggle="tab" href="#attachments-tab-pane" type="button" role="tab" aria-controls="attachments-tab-pane" aria-selected="false" title="Show expedition member attachments">Attachments</a>
 													</li>
 												</ul>
 												<div class="tab-content expedition-member-tab-content">


### PR DESCRIPTION
When either the 'SUP App' or 'PSAR' checkboxes are checked, ask the use if they want to add an attachment (if there isn't already an attachment of this type uploaded). Conversely, when the user adds an attachment, automatically check the associated checkbox. 

I also cleaned up some event handlers, adding an explicit method for the leader checkbox and organizing event handler register code.