### PR TITLE
Add non login rangers

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -256,7 +256,9 @@ CREATE TABLE IF NOT EXISTS config (
 	property VARCHAR(50) UNIQUE,
 	display_name VARCHAR(255) UNIQUE,
 	data_type config_data_type,
-	value VARCHAR(255)
+	value VARCHAR(255),
+	is_editable BOOLEAN DEFAULT true,
+	is_array BOOLEAN DEFAULT false
 );
 
 

--- a/web/css/climberdb.css
+++ b/web/css/climberdb.css
@@ -9,7 +9,9 @@
   --climberdb-header-menu-height: 60px;
   --fuzzy-search-bar-height: 60px;
   --climberdb-data-table-row-height: 60px;
-  --sunrise-linear-gradient-colors: #ffe7aa, #5abccd;/*linear-gradient(2deg, #44a9ba, #ffe7aad1);*/;
+  --sunrise-linear-gradient-blue: #5abccd;
+  --sunrise-linear-gradient-yellow: #ffe7aa;
+  --sunrise-linear-gradient-colors: var(--sunrise-linear-gradient-yellow), var(--sunrise-linear-gradient-blue);
 }
 
 html, body {
@@ -1402,10 +1404,14 @@ border-spacing: 0px;
   /*border:  1px solid #f28100;*/
   padding: 4px;
 }
-.climberdb-data-table th {
+.climberdb-data-table th  {
   background-color: #0a4664;/*#6bb6b9;*/
   color:  white;
   text-align: center;
+}
+/*for tables with multiple rows in the header, make the 
+whole header sticky*/
+.climberdb-data-table thead {
   position: sticky;
   top: 0;
   padding: 10px;

--- a/web/css/users.css
+++ b/web/css/users.css
@@ -2,6 +2,11 @@
 
 .main-content-wrapper {
 	background-image: linear-gradient(0deg, var(--sunrise-linear-gradient-colors));
+	justify-content: center;
+	display: flex;
+	flex-wrap: wrap;
+	padding-top: 0;
+	padding-left: 30px;
 }
 .sidebar-nav-group .nav-item.selected > a::after {
 	border-right: 15px solid #8bc0b3;
@@ -9,11 +14,11 @@
 
 .climberdb-data-table-wrapper {
 	display: flex;
+	flex-wrap: wrap;
 	justify-content: center;
 	position: relative;
-	padding-top: 30px;
+	/* padding-left: 100px;*/
 }
-
 
 .climberdb-data-table tbody > tr:not(.uneditable) td:not(.no-border) {
   background-color: rgba(255, 182, 0, 0.65);
@@ -22,10 +27,11 @@
   background-color: transparent;
 }
 .climberdb-data-table-wrapper table { 
-border-collapse: separate;
-border-radius: 10px;
-border-spacing: 0px;
-transform: translateX(105px); /*offset for the usually hidden edit buttons*/
+	border-collapse: separate;
+	border-radius: 10px;
+	border-spacing: 0px;
+/*	transform: translateX(105px); /*offset for the usually hidden edit buttons*/
+	width: 100%;
 }
 
 /*----- input field -------*/
@@ -69,4 +75,26 @@ tr.inactive .input-field {
   background-color: #219ebc40;
 }
 
+.no-login-role-column select{
+	min-width: 200px;
+}
 
+.add-user-button-wrapper {
+/*	d-flex justify-content-center pt-2*/
+	display: flex;
+	justify-content: center;
+	padding-top: 16px;
+	width: 100%;
+}
+/*.climberdb-data-table thead .clear-background-header,
+.climberdb-data-table thead .clear-background-header th {*/
+.clear-background-header,
+.clear-background-header th {
+	color: unset;
+	background-color: transparent;
+	font-size: 16px;
+	padding-top: 10px;
+}
+.clear-background-header.main-table-header th {
+	background-color: var(--sunrise-linear-gradient-blue);
+}

--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -126,17 +126,45 @@ def get_engine():
 	)
 
 
-def get_config_from_db():
+def get_config_from_db() -> dict:
+	"""
+	Retrieve saved configuration values for the web app from the 'config' table
+	and save it to the flask config
+	"""
 	engine = get_engine()
 	db_config = {}		
+	
+	# helper function to convert DB values (which are all strings) to the proper data type
+	def convert_value(value, data_type):
+		return (
+			float(value) if data_type == 'float' else  
+			int(value) if data_type == 'integer' else
+			value
+		)
+
 	with engine.connect() as conn:
 		cursor = conn.execute('TABLE config');
+	
 	for row in cursor:
-		app.config[row['property']] = (
-			float(row['value']) if row['data_type'] == 'float' else  
-			int(row['value']) if row['data_type'] == 'integer' else
-			row['value']
-		)
+		data_type = row['data_type']
+		property_name = row['property']
+		value = row['value']
+		try:
+			converted_value = (
+				[convert_value(v.strip(), data_type) for v in value.split(',')]
+				if row['is_array'] 
+				else convert_value(value, data_type)
+			)
+		except:
+			raise ValueError(f'''Invalid value for property "{property_name}" with data type "{data_type}": {value} ''')
+		
+		# Save value in Flask config and in a dict to return for the web app
+		app.config[property_name] = converted_value
+		db_config[property_name] = converted_value
+
+	return db_config
+
+# Call it
 get_config_from_db()
 
 
@@ -217,6 +245,11 @@ def add_header(response):
 def test():
 	
 	return os.getlogin()
+
+
+@app.route('/flask/config', methods=['POST'])
+def db_config_endpoint():
+	return get_config_from_db()
 
 
 # -------------- User Management ---------------- #

--- a/web/js/briefings.js
+++ b/web/js/briefings.js
@@ -1504,13 +1504,22 @@ class ClimberDBBriefings extends ClimberDB {
 	*/
 	fillBriefingDetailSelects(year=(new Date()).getFullYear()) {
 
+		const rangerRoleCodes = `${this.constants.userRoleCodes.ranger}, ${this.constants.userRoleCodes.noLoginRanger}`
 		var deferreds = [
 			// Fill expeditions
 			this.getExpeditionInfo(year)
 			,
 			// Get rangers 
-			this.queryDB(`SELECT id, first_name || ' ' || last_name As full_name FROM users WHERE user_role_code=${this.constants.userRoleCodes.ranger} AND user_status_code=2`)
-				.done(queryResultString => {
+			this.queryDB(`
+				SELECT 
+					id, 
+					first_name || ' ' || last_name As full_name 
+				FROM users 
+				WHERE 
+					user_role_code IN (${rangerRoleCodes}) AND 
+					user_status_code=2
+				ORDER BY first_name, last_name
+			`).done(queryResultString => {
 					const $input = $('#input-ranger');
 					for (const row of $.parseJSON(queryResultString)) {
 						$input.append(`<option class="" value="${row.id}">${row.full_name}</option>`);

--- a/web/js/climberdb.js
+++ b/web/js/climberdb.js
@@ -304,7 +304,7 @@ class ClimberDB {
 
 
 	loadConfigValues() {
-		$.post({
+		return $.post({
 			url: '/flask/config'
 		}).done(response => {
 			if (this.pythonReturnedError(response)) {

--- a/web/js/climberdb.js
+++ b/web/js/climberdb.js
@@ -223,7 +223,8 @@ class ClimberDB {
 				ranger: 2,
 				admin: 3,
 				superUser: 4,
-				readOnly: 5
+				readOnly: 5,
+				noLoginRanger: 6
 			},
 			userStatusCodes: {
 				active: 2,
@@ -303,21 +304,17 @@ class ClimberDB {
 
 
 	loadConfigValues() {
-		this.queryDB('SELECT property, data_type, value FROM config')
-			.done(queryResultString => {
-				if (this.queryReturnedError(queryResultString)) {
-					print('Problem querying config values');
-				} else {
-					for (const {property, data_type, value, ...rest} of $.parseJSON(queryResultString)) {
-						this.config[property] = 
-							data_type === 'integer' ? parseInt(value) : 
-							data_type === 'float' ? parseFloat(value) : 
-							data_type === 'boolean' ? value.toLowerCase().startsWith('t') :
-							value; // it's a string
-					}
-				}
-			})
+		$.post({
+			url: '/flask/config'
+		}).done(response => {
+			if (this.pythonReturnedError(response)) {
+				showModal('Invalid Configuration', 'There was a problem retrieving the app configuration: ' + response);
+			} else {
+				this.config = {...response}
+			}
+		})
 	}
+
 
 	configureMenu() {
 		$('body').prepend(`

--- a/web/js/config.js
+++ b/web/js/config.js
@@ -106,7 +106,7 @@ class ClimberDBConfig extends ClimberDB {
 
 	loadConfig() {
 
-		const sql = `TABLE config ORDER BY sort_order`;
+		const sql = `SELECT * FROM config WHERE is_editable ORDER BY sort_order`;
 		return this.queryDB(sql).done(queryResultString => {
 			// No need to check result
 			const result = $.parseJSON(queryResultString);

--- a/web/js/users.js
+++ b/web/js/users.js
@@ -518,6 +518,7 @@ class ClimberDBUsers extends ClimberDB {
 				user_role_code,
 				user_status_code 
 			FROM users 
+			WHERE user_role_code NOT IN (${this.config.no_login_user_roles.join(',')})
 			ORDER BY 
 				user_status_code DESC,
 				first_name, 

--- a/web/js/users.js
+++ b/web/js/users.js
@@ -514,17 +514,19 @@ class ClimberDBUsers extends ClimberDB {
 	onDeleteButtonClick(e) {
 		const $userRow = $(e.target).closest('tr');
 		const $table = $userRow.closest('.climberdb-data-table');
-		if ($table.is('#main-data-table')) {
+		if ($userRow.is('.new-user')) { 
+			// if it's a new user that hasn't been saved yet, 
+			//	just remove it
+			$userRow.fadeRemove();
+		} else if ($table.is('#main-data-table')) {
+			// Main data table users are only disabled, not deleted because user 
+			//	IDs need to persist (mostly for ref. integrity in the briefings table)
 			$userRow.find('.input-field[name=user_status_code]')
 				.val(-1)
 				.change();
 				this.saveEdits();
-		} else if ($userRow.is('.new-user')) { 
-			// new user in the no-login table
-			// just delete it
-			$userRow.fadeRemove();
 		} else {
-			// already saved user in no-login table
+			// an already saved user in no-login table
 			// update status to disabled in case there are any briefing records with this user assigned to it
 			this.queryDB(`UPDATE users SET user_status_code=-1 WHERE id=${parseInt($userRow.data('table-id'))} RETURNING id`)
 				.done(response => {

--- a/web/js/users.js
+++ b/web/js/users.js
@@ -340,6 +340,8 @@ class ClimberDBUsers extends ClimberDB {
 		$tr.find('select.input-field')
 			.change()
 			.attr('tabindex', 0);
+
+		return $tr;
 	}
 
 
@@ -360,7 +362,10 @@ class ClimberDBUsers extends ClimberDB {
 			// If the user is currently editing a row (but hasn't made any unsaved changes), 
 			//	turn off editing before adding the new row
 			this.disableAllEditing();
-			this.addNewUserRow($table);
+			const $tr = this.addNewUserRow($table);
+
+			// Scroll to the new row if necessary
+			$tr[0].scrollIntoView();
 		}
 
 	}

--- a/web/js/users.js
+++ b/web/js/users.js
@@ -3,6 +3,7 @@ class ClimberDBUsers extends ClimberDB {
 	constructor() {
 		super();
 		this.userRoleOptions = '';
+		this.noLoginRoleOptions = '';
 		this.userStatusOptions = '';
 		this.users = {};
 		return this;
@@ -39,10 +40,14 @@ class ClimberDBUsers extends ClimberDB {
 			const $select = $(e.target);
 			const $tr = $select.closest('tr');
 			$tr.toggleClass('inactive', $select.val() != 2);
-		})
+		});
 
-		$('.add-user-button').click(() => {
-			this.onaddUserRowButtonClick()
+		$(document).on('change', '[name=first_name],[name=last_name]', e => {
+			this.onFirstLastNameChange(e);
+		});
+
+		$('.add-user-button').click(e => {
+			this.onAddUserRowButtonClick(e)
 		});
 
 		$(document).on('click', '.delete-button', e => {
@@ -56,7 +61,7 @@ class ClimberDBUsers extends ClimberDB {
 	*/
 	disableAllEditing() {
 		// make all rows uneditable at first
-		$('#main-table-wrapper tbody tr')
+		$('.climberdb-data-table tbody tr')
 			.addClass('uneditable')
 			// turn off tab-ability for inputs and buttons in all other rows
 			.find('.input-field, .icon-button:not(.edit-button)')
@@ -156,16 +161,52 @@ class ClimberDBUsers extends ClimberDB {
 			}
 			
 			showModal(message, 'Duplicate username', 'confirm', footerButtons);
-
-			// If the edited user already exists, roll the username edits 
-			// on second thought, I don't think it's possible for the user to be old
-			/*const $tr = $input.closest('tr');
-			if (!$tr.is('.new-user')) {
-				const originalUserID = $tr.data('table-id');
-				$input.val(this.users[originalUserID].ad_username)
-			}*/
 		}
 	}
+
+
+	onFirstLastNameChange(e) {
+		const $tr = $(e.target).closest('tr');
+		const firstName = $tr.find('.input-field[name=first_name]').val();
+		const lastName = $tr.find('.input-field[name=last_name]').val();
+		const matchedUsers = Object.values(this.users)
+			.filter(u => u.first_name === firstName && u.last_name === lastName);
+		var onConfirmClickHandler = () => {};
+		
+		if (matchedUsers.length) {
+			const status = matchedUsers[0].user_status_code;
+			const matchedUserID = matchedUsers[0].id;
+			var message = `The user <strong>${firstName} ${lastName}</strong> already exists `
+			var footerButtons = '';
+			if (status == -1) {
+				message += `but the account is currently disabled. Would you like to enable it?`;
+				onConfirmClickHandler = () => {
+					('#alert-modal .confirm-button').click(() => {
+						this.discardEdits(); //remove new user
+						const $tr = $(`.climberdb-data-table tbody tr[data-table-id=${matchedUserID}]`);
+						// set user status code to 'enabled' for matched user
+						// 	this will do nothing for non-login users since there is no status field
+						$tr.ariaHide(false)
+							.removeClass('uneditable')
+							.find('.input-field[name=user_status_code]')
+								.val(2)
+								.change();
+					});
+				}
+
+				footerButtons = `
+					<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">No</button>
+					<button class="generic-button modal-button primary-button close-modal confirm-button" data-dismiss="modal">Yes</button>
+				`;
+			} else {
+				message += 'and each user must have a unique first and last name.'
+				footerButtons = '';
+			}
+			
+			showModal(message, 'Duplicate user', 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
+		}
+	}
+
 
 	/*
 	Helper method to add new row to the users table
@@ -234,6 +275,47 @@ class ClimberDBUsers extends ClimberDB {
 		`).appendTo($('#main-table-wrapper tbody'));
 	}
 
+	addNoLoginRow({data={}}={}) {
+		return $(`
+			<tr class="uneditable" data-table-id="${data.id}">
+				<td>
+					<span>
+						<input class="input-field user-table-input" type="text" name="first_name" title="First Name" placeholder="First name" value="${data.first_name}" autocomplete="__never" tabindex=-1>
+					</span>
+				</td>
+				<td>
+					<span>
+						<input class="input-field user-table-input" type="text" name="last_name" title="Last Name" placeholder="Last name" value="${data.last_name}" autocomplete="__never" tabindex=-1>
+					</span>
+				</td>
+				<td>
+					<span>
+						<select class="input-field user-table-input" name="user_role_code" title="User role" tabindex=-1>
+							${this.noLoginRoleOptions}
+						</select>
+					</span>
+				</td>
+				<td class="no-border">
+					<button class="icon-button edit-button slide-up-on-focus has-motion" title="Toggle editing" tabindex=0>
+						<i class="fa fa-edit fa-lg"></i>
+						<label class="icon-button-label ">edit</label>
+					</button>
+				</td>
+				<td class="no-border">
+					<button class="icon-button save-button slide-up-on-focus has-motion" title="Save edits" tabindex=-1>
+						<i class="fa fa-save fa-lg"></i>
+						<label class="icon-button-label ">save</label>
+					</button>
+				</td>
+				<td class="no-border">
+					<button class="icon-button delete-button slide-up-on-focus has-motion" title="Disable user" tabindex=-1>
+						<i class="fa fa-trash fa-lg"></i>
+						<label class="icon-button-label ">delete</label>
+					</button>
+				</td>
+			</tr>
+		`).appendTo($('#no-login-table-wrapper tbody'));
+	}
 
 	/*
 	Add a row for a new user to the table. For now, an admin user has full control 
@@ -241,8 +323,8 @@ class ClimberDBUsers extends ClimberDB {
 	ad_username. I might want to move to an LDAP query and limiting the choices for 
 	ad_username or maybe handle new user creation via emails
 	*/
-	addNewUserRow() {
-		const $tr = this.addUserRow();
+	addNewUserRow($table) {
+		const $tr = $table.is('#main-data-table') ? this.addUserRow() : this.addNoLoginRow();
 		$tr.addClass('new-user')
 			.removeClass('uneditable')
 			.find('td.uneditable')
@@ -264,20 +346,21 @@ class ClimberDBUsers extends ClimberDB {
 	/*
 	Event handler for add new user button. 
 	*/
-	onaddUserRowButtonClick() {
+	onAddUserRowButtonClick(e) {
+		const $table = $($(e.target).closest('button').data('target'))
 		// if there's already a new user, force the user to save or discard that one
-		if ($('.new-user').length) {
+		if ($table.find('.new-user').length) {
 			showModal('You already created a new user. Either save those changes or delete that user before creating another one.', 'Save Error');
 			return;
 		}
 		// If the user is currently editing
-		if ($('.input-field.dirty').length) {
+		if ($table.find('.input-field.dirty').length) {
 			this.confirmSaveEdits({afterActionCallbackStr: 'climberDB.addNewUserRow()'})
 		} else {
 			// If the user is currently editing a row (but hasn't made any unsaved changes), 
 			//	turn off editing before adding the new row
 			this.disableAllEditing();
-			this.addNewUserRow();
+			this.addNewUserRow($table);
 		}
 
 	}
@@ -336,7 +419,7 @@ class ClimberDBUsers extends ClimberDB {
 				}
 
 				// Send activation email for a new user
-				if (isInsert) {
+				if (isInsert && !this.config.no_login_user_roles.includes(userInfo.user_role_code)) {
 					userID = result.id;
 					$tr.attr('data-table-id', userID)
 						.removeClass('new-user')
@@ -415,7 +498,7 @@ class ClimberDBUsers extends ClimberDB {
 		`;
 
 		showModal(
-			`You have unsaved edits to this expedition. Would you like to <strong>Save</strong> or <strong>Discard</strong> them? Click <strong>Cancel</strong> to continue editing this expedition.`,
+			`You have unsaved edits to this user. Would you like to <strong>Save</strong> or <strong>Discard</strong> them? Click <strong>Cancel</strong> to continue editing this user.`,
 			'Save edits?',
 			'alert',
 			footerButtons
@@ -425,10 +508,30 @@ class ClimberDBUsers extends ClimberDB {
 
 	onDeleteButtonClick(e) {
 		const $userRow = $(e.target).closest('tr');
-		$userRow.find('.input-field[name=user_status_code]')
-			.val(-1)
-			.change();
-		this.saveEdits();
+		const $table = $userRow.closest('.climberdb-data-table');
+		if ($table.is('#main-data-table')) {
+			$userRow.find('.input-field[name=user_status_code]')
+				.val(-1)
+				.change();
+				this.saveEdits();
+		} else if ($userRow.is('.new-user')) { 
+			// new user in the no-login table
+			// just delete it
+			$userRow.fadeRemove();
+		} else {
+			// already saved user in no-login table
+			// update status to disabled in case there are any briefing records with this user assigned to it
+			this.queryDB(`UPDATE users SET user_status_code=-1 WHERE id=${parseInt($userRow.data('table-id'))} RETURNING id`)
+				.done(response => {
+					if (this.queryReturnedError(response)) {
+						showModal('Database Error', 'The user could not be disabled because the system encountered an unexpected error: ' + response)
+					} else {
+						$userRow.fadeRemove()
+					}
+				}).fail((xhr, status, error) => {
+					showModal('Database Error', 'The user could not be disabled because the system encountered an unexpected error: ' + error)
+				});
+		}
 	}
 
 
@@ -491,10 +594,15 @@ class ClimberDBUsers extends ClimberDB {
 
 	loadSelectOptions() {
 		return [
-			this.queryDB('TABLE user_role_codes ORDER BY sort_order;').done(queryResultString => {
+			this.queryDB(`SELECT name, code FROM user_role_codes WHERE code NOT IN (${this.config.no_login_user_roles.join(',')}) ORDER BY sort_order;`).done(queryResultString => {
 				// No need to check result
 				const codes = $.parseJSON(queryResultString);
 				this.userRoleOptions = codes.map(({code, name}) => `<option value=${code}>${name}</option>`).join('\n');
+			}),
+			this.queryDB(`SELECT name, code FROM user_role_codes WHERE code IN (${this.config.no_login_user_roles.join(',')}) ORDER BY sort_order;`).done(queryResultString => {
+				// No need to check result
+				const codes = $.parseJSON(queryResultString);
+				this.noLoginRoleOptions = codes.map(({code, name}) => `<option value=${code}>${name}</option>`).join('\n');
 			}),
 			this.queryDB('TABLE user_status_codes ORDER BY sort_order;').done(queryResultString => {
 				// No need to check result
@@ -518,7 +626,6 @@ class ClimberDBUsers extends ClimberDB {
 				user_role_code,
 				user_status_code 
 			FROM users 
-			WHERE user_role_code NOT IN (${this.config.no_login_user_roles.join(',')})
 			ORDER BY 
 				user_status_code DESC,
 				first_name, 
@@ -527,10 +634,13 @@ class ClimberDBUsers extends ClimberDB {
 		return this.queryDB(sql).done(queryResultString => {
 			// No need to check result
 			const result = $.parseJSON(queryResultString);
+			const noLoginRoles = this.config.no_login_user_roles;
 			for (const row of result) {
 				// Save in-memory data for rolling back edits
 				this.users[row.id] = {...row};
-				const $tr = this.addUserRow({data: row});
+				const $tr = noLoginRoles.includes(parseInt(row.user_role_code)) ? 
+					this.addNoLoginRow({data: row}) : 
+					this.addUserRow({data: row});
 				$tr.find('select[name="user_role_code"]')
 					.val(row.user_role_code);
 				$tr.find('select[name="user_status_code"]')

--- a/web/users.html
+++ b/web/users.html
@@ -44,7 +44,7 @@
 								<th></th>
 								<th></th>
 								<th class="d-flex justify-content-end pb-3">
-									<button class="generic-button add-user-button" title="Add new user" data-target="#main-table">Add new user</button>
+									<button class="generic-button add-user-button" title="Add new user" data-target="#main-data-table">Add new user</button>
 								</th>
 							</tr>
 							<tr>

--- a/web/users.html
+++ b/web/users.html
@@ -32,8 +32,21 @@
 			<!--main content -->
 			<div class="main-content-wrapper">
 				<div id="main-table-wrapper" class="climberdb-data-table-wrapper">
+					
 					<table id="main-data-table" class="climberdb-data-table">
 						<thead>
+							<tr class="clear-background-header main-table-header">
+								<th>
+									<h4 class="text-left">Accounts with Logins</h4>
+								</th>
+								<th></th>
+								<th></th>
+								<th></th>
+								<th></th>
+								<th class="d-flex justify-content-end pb-3">
+									<button class="generic-button add-user-button" title="Add new user" data-target="#main-table">Add new user</button>
+								</th>
+							</tr>
 							<tr>
 								<th>Windows Username</th>
 								<th>First Name</th>
@@ -46,9 +59,29 @@
 						<tbody></tbody>
 					</table>
 				</div>
-				<div class="d-flex justify-content-center pt-2">
-					<button class="generic-button add-user-button" title="Add new user">Add new user</button>
+
+				<div id="no-login-table-wrapper" class="climberdb-data-table-wrapper mt-5">
+					<table id="no-login-data-table" class="climberdb-data-table">
+						<thead>
+							<tr class="clear-background-header">
+								<th>
+									<h4 class="text-left">Rangers/Volunteers without Logins</h4>
+								</th>
+								<th></th>
+								<th class="d-flex justify-content-end">
+									<button class="generic-button add-user-button" title="Add new user" data-target="#no-login-data-table">Add no-login user</button>
+								</th>
+							</tr>
+							<tr>
+								<th>First Name</th>
+								<th>Last Name</th>
+								<th class="no-login-role-column">Role</th>
+							</tr>
+						</thead>
+						<tbody></tbody>
+					</table>
 				</div>
+
 			</div><!--main-content-->
 		</div>
 	</main>


### PR DESCRIPTION
Rangers who aren't NPS employees (i.e., volunteers) don't have AD logins, and therefore can't access the DB. Office staff still need to be able to assign them to briefings though. I added a "no-login" user table that only shows users with this role. 

I also had to make adjustments to the layout/CSS for the users table to make it sensible given the additional table.

There were also two tangentially related bugs: 
1. I wasn't actually returning the `loadConfigValues()` promise, so config values weren't necessarily retrieved before other stuff that depended on them happened
2. When a user deletes a `.new-user` row, it should be removed in either users table rather than just the no-login table. I was getting an error when trying to remove a regular login user because there wasn't actually a record to disable