### PR TITLE
clean up name 'saveEditsPython' and remaining 'queryReturnedError'

### DIFF
--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -1229,7 +1229,7 @@ def query_expeditions():
 		).order_by(
 			*order_by
 		).distinct()
-	
+
 	with ReadSession() as session: 
 		result = session.execute(statement)
 

--- a/web/js/briefings.js
+++ b/web/js/briefings.js
@@ -236,7 +236,7 @@ class ClimberDBBriefings extends ClimberDB {
 		});
 
 		$('#save-button').click(e => {
-			this.saveEditsPython();
+			this.saveEdits();
 		})
 
 		$('#delete-button').click(e => {
@@ -577,7 +577,7 @@ class ClimberDBBriefings extends ClimberDB {
 	}
 
 
-	saveEditsPython() {
+	saveEdits() {
 		showLoadingIndicator('saveEdits');
 
 		if (!$('.appointment-details-drawer .input-field.dirty').length) {

--- a/web/js/climberdb.js
+++ b/web/js/climberdb.js
@@ -247,7 +247,7 @@ class ClimberDB {
 			data: urlParams.testClientSecret ? {client_secret: urlParams.testClientSecret} : {},
 			cache: false
 		}).done((resultString) => {
-			if (this.queryReturnedError(resultString)) {
+			if (this.pythonReturnedError(resultString)) {
 				throw 'User role query failed: ' + resultString;
 			} else {
 				const result = typeof resultString === 'object' ? resultString : $.parseJSON(resultString);

--- a/web/js/climbers.js
+++ b/web/js/climbers.js
@@ -574,7 +574,7 @@ class ClimberForm {
 		});
 
 		$('#save-button').click(e => {
-			this.saveEditsPython()
+			this.saveEdits()
 		});
 
 		$('.climber-form .delete-card-button').click(e => {
@@ -1115,7 +1115,7 @@ class ClimberForm {
 	or related records (i.e., emergency contacts) or completely new 
 	climber inserts (if the form is being shown as a modal)
 	*/
-	saveEditsPython() {
+	saveEdits() {
 
 		const now = getFormattedTimestamp(new Date(), {format: 'datetime'});
 		const userName = this._parent.userInfo.ad_username;
@@ -1290,7 +1290,7 @@ class ClimberForm {
 			});
 			$('#alert-modal .save-button').click(() => {
 				showLoadingIndicator();
-				this.saveEditsPython(); 
+				this.saveEdits(); 
 				afterActionCallback.call();
 			});
 		}
@@ -1653,7 +1653,7 @@ class ClimberDBClimbers extends ClimberDB {
 	from.
 	*/
 	saveModalClimber() {
-		const deferred = this.climberForm.saveEditsPython();
+		const deferred = this.climberForm.saveEdits();
 		if (deferred) {	
 			deferred.done(response => {
 				if (!this.pythonReturnedError(response)) {
@@ -1736,7 +1736,7 @@ class ClimberDBClimbers extends ClimberDB {
 
 
 	saveEdits() {
-		this.climberForm.saveEditsPython();
+		this.climberForm.saveEdits();
 	}
 
 	/*
@@ -2062,7 +2062,7 @@ class ClimberDBClimbers extends ClimberDB {
 	queryClimberByID(climberID) {
 		const deferred = this.queryClimbers({climberID: climberID})
 			.done(queryResultString => {
-				if (!this.queryReturnedError(queryResultString)) {
+				if (!this.pythonReturnedError(queryResultString)) {
 					this.currentRecordSetIndex = 1;
 				}
 			});
@@ -2097,7 +2097,7 @@ class ClimberDBClimbers extends ClimberDB {
 
 		this.climberForm.deleteClimber(climberID)
 			.done(queryResultString => {
-				if (!this.queryReturnedError(queryResultString)) {
+				if (!this.pythonReturnedError(queryResultString)) {
 					const $item = $(`#item-${climberID}`);
 					const deletedClimberIsSelected = $item.is('.selected');
 					const $nextItem = $item.next().length ? $item.next() : $item.prev();
@@ -2333,7 +2333,7 @@ class ClimberDBClimbers extends ClimberDB {
 					showLoadingIndicator('mergeClimbers');
 					this.deleteClimber(mergeClimberID)
 						.done(response => {
-							if (!this.queryReturnedError(response)) {
+							if (!this.pythonReturnedError(response)) {
 								// Update .climber-select
 								this.onMergeClimberSearchKeyup();
 								$('.merge-climber-details-container').collapse('hide');

--- a/web/js/query.js
+++ b/web/js/query.js
@@ -1642,17 +1642,17 @@ class ClimberDBQuery extends ClimberDB {
 
 
 	queryRouteCodes() {
-		return this.queryDB(`
+		return this.queryDB({sql: `
 			SELECT route_codes.*, mountain_codes.name AS mountain_name 
 			FROM ${this.dbSchema}.route_codes 
 				JOIN ${this.dbSchema}.mountain_codes ON mountain_codes.code=route_codes.mountain_code 
 			WHERE route_codes.sort_order IS NOT NULL
 			ORDER BY mountain_codes.sort_order, route_codes.sort_order
-		`).done(queryResultString => {
+		`}).done(response => {
 			const $routeSelects = $('.route-code-parameter-input');
 			const $mountainSelects = $('.mountain-code-parameter-input');
-			if (!this.queryReturnedError(queryResultString)) {
-				for (const route of $.parseJSON(queryResultString)) {
+			if (!this.pythonReturnedError(response)) {
+				for (const route of response.data || []) {
 					this.routeCodes[route.code] = {...route};
 					$routeSelects.append($(`<option value="${route.code}">${route.name}</option>`));
 				


### PR DESCRIPTION
There were a few more `queryReturnedError()` calls even though I deleted the function. I additionally forgot to rename `saveEditsPython()` to just `saveEdits()` when cleaning up. Also, apparently I still had a few calls to the old `queryDB()` that was hitting the PHP backend, so I cleaned those up too.