### PR TITLE
make route order consistently set and displayed

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -558,6 +558,7 @@ CREATE VIEW expedition_info_view AS
 		transactions.transaction_date, 
 		transactions.id,
 		itinerary_locations.display_order,
+		expedition_member_routes.route_order,
 		attachments.id;
 
 
@@ -1262,10 +1263,29 @@ ALTER FUNCTION clone_schema(text, text, boolean)
   OWNER TO postgres;
 
 
-select clone_schema('public', 'dev', true);
-GRANT USAGE ON SCHEMA dev TO climberdb_read;
-GRANT SELECT ON ALL TABLES IN SCHEMA dev TO climberdb_read;
-GRANT SELECT ON ALL SEQUENCES IN SCHEMA dev TO climberdb_read;
-GRANT USAGE ON SCHEMA dev TO climberdb_admin;
-GRANT ALL ON ALL TABLES IN SCHEMA dev TO climberdb_admin;
-GRANT ALL ON ALL SEQUENCES IN SCHEMA dev TO climberdb_admin;
+-- create a convenience function for granting permissions after re-creating 
+--	schemas or views
+CREATE OR REPLACE FUNCTION grant_permissions() 
+	RETURNS void AS
+$BODY$
+	BEGIN
+		GRANT USAGE ON SCHEMA public TO climberdb_read;
+		GRANT SELECT ON ALL TABLES IN SCHEMA public TO climberdb_read;
+		GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO climberdb_read;
+		GRANT USAGE ON SCHEMA public TO climberdb_admin;
+		GRANT ALL ON ALL TABLES IN SCHEMA public TO climberdb_admin;
+		GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO climberdb_admin;
+
+		GRANT USAGE ON SCHEMA dev TO climberdb_read;
+		GRANT SELECT ON ALL TABLES IN SCHEMA dev TO climberdb_read;
+		GRANT SELECT ON ALL SEQUENCES IN SCHEMA dev TO climberdb_read;
+		GRANT USAGE ON SCHEMA dev TO climberdb_admin;
+		GRANT ALL ON ALL TABLES IN SCHEMA dev TO climberdb_admin;
+		GRANT ALL ON ALL SEQUENCES IN SCHEMA dev TO climberdb_admin;
+	END;
+$BODY$
+  LANGUAGE plpgsql VOLATILE
+  COST 100;
+
+--SELECT clone_views('public', 'dev'), grant_permissions();
+SELECT clone_schema('public', 'dev', true), grant_permissions();

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -4555,7 +4555,7 @@ class ClimberDBExpeditions extends ClimberDB {
 					.change();
 			if ($card.is('.new-card')) {
 				$card.find('.data-list-item:not(.cloneable) .input-field:not(.route-code-header-input)[name="route_order"]')
-						.val($card.index() - 1) // -1 because .cloneable card is 0th
+						.val($card.index())
 						.change();
 			}
 		}


### PR DESCRIPTION
The `route_order` field is set in two different places. The both use the `.index()` of the card element, but one was subtracting 1 from the returned index to account for the `.cloneable` card and the other wasn't. Separately, the `expdedition_info_view` wasn't sorting by the `route_order` field at all. Closes #68 