### PR TITLE
toggle beforeunload listener on/off

### DIFF
--- a/web/expeditions.html
+++ b/web/expeditions.html
@@ -208,7 +208,7 @@
 										<span class="null-input-indicator">&lt; null &gt;</span>
 									</div>	
 									<div class="field-container col-sm-6">
-										<select id="input-air_taxi" class="input-field default filled-by-default needs-filled-by-default" name="air_taxi_code" data-table-name="expeditions" placeholder="Air taxi" title="Air taxi" type="text"></select>
+										<select id="input-air_taxi" class="input-field default" name="air_taxi_code" data-table-name="expeditions" placeholder="Air taxi" title="Air taxi" type="text" data-default-value=""></select>
 										<span class="required-indicator">*</span>
 										<label class="field-label" for="input-air_taxi">Air taxi</label>
 										<span class="null-input-indicator">&lt; null &gt;</span>

--- a/web/js/briefings.js
+++ b/web/js/briefings.js
@@ -704,6 +704,7 @@ class ClimberDBBriefings extends ClimberDB {
 				}
 
 				$('.input-field.dirty').removeClass('dirty');
+				this.toggleBeforeUnload(false);
 
 			}
 		}).fail((xhr, status, error) => {
@@ -751,6 +752,8 @@ class ClimberDBBriefings extends ClimberDB {
 		// Hide the details drawer
 		$('.appointment-details-drawer').removeClass('show');
 		$('.briefing-appointment-container.selected').removeClass('selected');
+
+		this.toggleBeforeUnload(false);
 	}
 
 	/*
@@ -812,6 +815,7 @@ class ClimberDBBriefings extends ClimberDB {
 		//	matter if it happens when it's enabled too
 		this.edits = {};
 		$('.input-field.dirty').removeClass('dirty');
+		this.toggleBeforeUnload(false);
 	}
 
 	/*
@@ -934,6 +938,7 @@ class ClimberDBBriefings extends ClimberDB {
 	Record value changes in the .edits property
 	*/
 	onInputChange(e) {
+
 		const input = e.target;
 		const fieldName = input.name;
 		const inputValue = input.value;
@@ -941,6 +946,8 @@ class ClimberDBBriefings extends ClimberDB {
 		const $input = $(input);
 		$input.addClass('dirty');
 		
+		this.toggleBeforeUnload(true)
+
 		// If this is a new briefing, there's no in-memory data to compare to
 		const $selectedAppointment = $('.briefing-appointment-container.selected');
 		if ($selectedAppointment.is('.new-briefing')) return;
@@ -951,9 +958,13 @@ class ClimberDBBriefings extends ClimberDB {
 		const dbValue = this.briefings[dateString][briefingID][fieldName];
 		if (inputValue == dbValue) {
 			$input.removeClass('dirty');
-			delete this.edits[fieldName];
+			delete this.edits[fieldName];		
 		}
-		
+
+		// If there are no more dirty inputs, toggle beforeunload event
+		if (!$('.input-field.dirty:not(.filled-by-default)').length) {
+			this.toggleBeforeUnload(false);
+		}
 	}
 
 

--- a/web/js/climbers.js
+++ b/web/js/climbers.js
@@ -647,7 +647,10 @@ class ClimberForm {
 	When an input field changes, 
 	*/
 	onInputChange(e) {
+
 		const $input = $(e.target).addClass('dirty').removeClass('error');
+
+		this._parent.toggleBeforeUnload(true);
 
 		// This is an insert if it's a descendant of either a .new-card or modal .climber-form. In that case,
 		//	changes will be captured when the save button is clicked
@@ -661,7 +664,7 @@ class ClimberForm {
 		const editObject = this.edits.updates; // get reference for shorthand
 		const dbValue = this.selectedClimberInfo[tableName][dbID][fieldName];
 		// If the input value matches the DB value, remove the edit and the .dirty class
-		if (dbValue == $input.val()) {
+		if (valuesAreEqual(dbValue, $input.val())) {
 			$input.removeClass('dirty');
 			if (editObject[tableName]) {
 				if (editObject[tableName][dbID]) {
@@ -676,6 +679,11 @@ class ClimberForm {
 			if (!(tableName in editObject)) editObject[tableName] = {};
 			if (!(dbID in editObject[tableName])) editObject[tableName][dbID] = {};
 			editObject[tableName][dbID][fieldName] = this.getInputFieldValue($input);
+		}
+
+		// If there are no more dirty inputs, toggle beforeunload event
+		if (!$('.input-field.dirty:not(.filled-by-default)').length) {
+			this._parent.toggleBeforeUnload(false);
 		}
 	}
 
@@ -1107,6 +1115,8 @@ class ClimberForm {
 		// Reset edits
 		this.edits.updates = {};
 
+		// turn off the beforeunload event listener
+		this._parent.toggleBeforeUnload(false);
 	}
 
 
@@ -1265,6 +1275,9 @@ class ClimberForm {
 				}
 
 				$('.climber-form .input-field.dirty').removeClass('dirty');
+
+				// turn off the beforeunload event listener
+				this._parent.toggleBeforeUnload(false);
 			}
 		}).fail((xhr, status, error) => {
 			showModal(`An unexpected error occurred while saving data to the database: ${error}. Make sure you're still connected to the NPS network and try again. Contact your database adminstrator if the problem persists.`, 'Unexpected error');

--- a/web/js/config.js
+++ b/web/js/config.js
@@ -47,6 +47,7 @@ class ClimberDBConfig extends ClimberDB {
 	original database value
 	*/
 	onInputChange(e) {
+
 		const $input = $(e.target);
 		// check if the value is different from the in-memory value
 		let isDirty = false;
@@ -56,6 +57,7 @@ class ClimberDBConfig extends ClimberDB {
 			isDirty = true;
 		}
 		$input.toggleClass('dirty', isDirty);
+		this.toggleBeforeUnload($('.input-field.dirty').length);
 		$('#save-button').ariaTransparent($('.input-field.dirty').length);
 	}
 
@@ -295,6 +297,9 @@ class ClimberDBConfig extends ClimberDB {
 
 				$([...$configInputs, ...$cuaInputs]).removeClass('dirty');
 				$('#save-button').ariaTransparent();
+
+				// turn off beforeunload event listener
+				this.toggleBeforeUnload(false);
 			}
 		}).fail((xhr, status, error) => {
 			showModal(`An unexpected error occurred while saving data to the database: ${error}. Make sure you're still connected to the NPS network and try again. Contact your <a href="mailto:${this.config.db_admin_email}">database adminstrator</a> if the problem persists.`, 'Unexpected error');

--- a/web/js/users.js
+++ b/web/js/users.js
@@ -110,6 +110,7 @@ class ClimberDBUsers extends ClimberDB {
 	original database value
 	*/
 	onInputChange(e) {
+		
 		const $input = $(e.target);
 		const $tr = $input.closest('tr');
 		const userID = $tr.data('table-id');
@@ -121,6 +122,9 @@ class ClimberDBUsers extends ClimberDB {
 			isDirty = dbValue != $input.val();
 		}
 		$input.toggleClass('dirty', isDirty);
+
+		// Toggle beforeunload event depending on whethe there are any dirty inputs
+		this.toggleBeforeUnload($('.input-field.dirty:not(.filled-by-default)').length);
 	}
 
 
@@ -423,6 +427,8 @@ class ClimberDBUsers extends ClimberDB {
 				$inputs.removeClass('dirty');
 				$tr.addClass('uneditable');
 
+				this.toggleBeforeUnload(false);
+
 				// update in-memory data
 				const userInfo = (this.users[userID] = this.users[userID] || {});
 				for (const [field, value] of Object.entries(values)) {
@@ -493,6 +499,9 @@ class ClimberDBUsers extends ClimberDB {
 
 		$('.input-field.dirty').removeClass('dirty');
 		$tr.addClass('uneditable');
+
+		// turn off beforeunload event listener
+		this.toggleBeforeUnload(false);
 	}
 
 	/*


### PR DESCRIPTION
Previously, the `beforeunload` alert would be triggered on some pages when the user hadn't actually made any edits. This was mostly because my code to detect real changes wasn't very robust. Also, modern browsers don't allow you to customize the alert or even the event handler. If there's an event listener, the browser will show the alert asking the user to confirm leaving the page. To only show this alert when appropriate, I created a helper method to toggle it on or off.

These changes also subsequently resolve #80 because to detect actual changes, I had to fix my method for comparing input values. I created a helper function to do so, and it considers an empty string and either `null` or `undefined` to be equal. This prevents the `.createNewExpedition()` method from assigning the `expected_expedition_size` field an empty string.