### PR TITLE
Refactor modal onclick strings

### DIFF
--- a/web/js/briefings.js
+++ b/web/js/briefings.js
@@ -761,17 +761,7 @@ class ClimberDBBriefings extends ClimberDB {
 	*/
 	confirmSaveEdits({afterActionCallback=()=>{}}={}) {
 		//@param afterActionCallback: a callable function to be called after either the Save or Discard button is clicked
-
-		// const onConfirmClick = `
-		// 	showLoadingIndicator('saveEdits');
-		// 	climberDB.saveEdits() 
-		// `;
-		
-		// const footerButtons = `
-		// 	<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">Cancel</button>
-		// 	<button class="generic-button modal-button danger-button close-modal" data-dismiss="modal" onclick="climberDB.discardEdits();${afterActionCallbackStr};${afterDiscardCallbackStr}">Discard</button>
-		// 	<button class="generic-button modal-button primary-button close-modal" data-dismiss="modal" onclick="${onConfirmClick};${afterActionCallbackStr};${afterSaveCallbackStr}">Save</button>
-		// `;		
+	
 		const footerButtons = `
 			<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">Cancel</button>
 			<button class="generic-button modal-button danger-button discard-button close-modal" data-dismiss="modal">Discard</button>

--- a/web/js/climberdb.js
+++ b/web/js/climberdb.js
@@ -23,7 +23,7 @@ function print(i) {
 
 function getDefaultModalFooterButtons(modalType) {
 	return  modalType === 'confirm' ? 
-			'<button class="generic-button secondary-button modal-button close-modal" data-dismiss="modal">Close</button>' +
+			'<button class="generic-button secondary-button modal-button close-modal confirm-button" data-dismiss="modal">Close</button>' +
 			'<button class="generic-button modal-button close-modal confirm-button" data-dismiss="modal">OK</button>'
 		  :
 		'<button class="generic-button modal-button close-modal confirm-button" data-dismiss="modal">OK</button>'
@@ -691,16 +691,24 @@ class ClimberDB {
 	*/
 	confirmLogout() {
 		// Set the expiration for the current user's session to now if they confirm. Then go to the sign-in page
-		const onConfirmClick = `
-			climberDB.loginInfo.expiration = ${new Date().getTime()};
-			window.localStorage.login = JSON.stringify(climberDB.loginInfo);
-			window.location.href='index.html';
-		`;
+		const onConfirmClickHandler = () => {
+			$('#alert-modal .confirm-button').click(() => {
+				this.loginInfo.expiration = new Date().getTime();
+				window.localStorage.login = JSON.stringify(this.loginInfo);
+				window.location.href = 'index.html';
+			});
+		}
 		const footerButtons = `
-			<button class="generic-button modal-button close-modal" data-dismiss="modal" onclick="${onConfirmClick}">Yes</button>
+			<button class="generic-button modal-button close-modal confirm-button" data-dismiss="modal">Yes</button>
 			<button class="generic-button secondary-button modal-button close-modal" data-dismiss="modal">No</button>';
 		`;
-		showModal('Are you sure you want to log out? Any unsaved data will be lost', 'Log out?', 'confirm', footerButtons);
+		showModal(
+			'Are you sure you want to log out? Any unsaved data will be lost', 
+			'Log out?', 
+			'confirm', 
+			footerButtons,
+			{eventHandlerCallable: onConfirmClickHandler}
+		);
 	}
 
 
@@ -2100,8 +2108,22 @@ class ClimberDB {
 					if (this.loginInfo.username !== username || this.loginInfo.expiration < new Date().getTime()) {
 						$('#climberdb-main-content').empty();
 						hideLoadingIndicator();
-						const footerButtons = `<button class="generic-button modal-button close-modal" data-dismiss="modal" onclick="window.location.href='index.html?referer=${encodeURI(window.location.href)}'">OK</button>`;
-						showModal('Your session has expired. Click OK to log in again.', 'Session expired', 'alert', footerButtons, {dismissable: false});
+						const onConfirmClickHandler = () => {
+							$('#alert-modal .modal-button').click(() => {
+								window.location.href = `index.html?referer=${encodeURI(window.location.href)}`
+							})
+						}
+						const footerButtons = `<button class="generic-button modal-button close-modal" data-dismiss="modal">OK</button>`;
+						showModal(
+							'Your session has expired. Click OK to log in again.', 
+							'Session expired', 
+							'alert', 
+							footerButtons, 
+							{	
+								eventHandlerCallable: onConfirmClickHandler,
+								dismissable: false
+							}
+						);
 					}
 				}
 				if (window.location.pathname !== '/index.html' && this.userInfo.user_status_code != 2) {

--- a/web/js/climbers.js
+++ b/web/js/climbers.js
@@ -2162,23 +2162,32 @@ class ClimberDBClimbers extends ClimberDB {
 		// If this isn't an admin, check if the climber belongs to any expeditions
 		if (!this.userInfo.isAdmin) {
 			if (climberInfo.expedition_name) { // will be null if climber isn't/wasn't on any expeditions
-				showModal(`You can't delete ${climberInfo.first_name} ${climberInfo.last_name}'s climber profile because they are a member of at least one expedition. You must remove them from all expeditions they're a member of before their profile can be deleted.`, 'Invalid Operation')
+				showModal(
+					`You can't delete ${climberInfo.first_name} ${climberInfo.last_name}'s climber profile` + 
+						' because they are a member of at least one expedition. You must remove them from all' + 
+						' expeditions they\'re a member of before their profile can be deleted.', 
+					'Invalid Operation'
+				);
 				return;
 			}
 		}
 
 		const climberID = $('.query-result-list-item.selected').attr('id').replace('item-','');
-		const onConfirmClick = `
-			climberDB.deleteClimber(${climberID});
-		`;
-		
+		const onConfirmClickHandler = () => {
+			$('#alert-modal .confirm-button').click(() => {
+				this.deleteClimber(climberID);
+			});
+		}
 		const footerButtons = `
 			<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">No</button>
-			<button class="generic-button modal-button danger-button close-modal" data-dismiss="modal" onclick="${onConfirmClick}">Yes</button>
+			<button class="generic-button modal-button danger-button close-modal confirm-button" data-dismiss="modal">Yes</button>
 		`;
 		let message = `Are you sure you want to <strong>permanently delete this climber</strong>? This action cannot be undone`;
-		if (climberInfo.expedition_name) message += ' and all information about their climbs will be delete including transaction history, medical issues, and whether or not they summited.'
-		showModal(message, `Delete climber?`, 'confirm', footerButtons);
+		if (climberInfo.expedition_name) {
+			message += ' and all information about their climbs will be delete including transaction history,' + 
+				' medical issues, and whether or not they summited.';
+		}
+		showModal(message, `Delete climber?`, 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
 	}
 
 

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -1191,7 +1191,7 @@ class ClimberDBExpeditions extends ClimberDB {
 						</select>
 				</div>
 			`;
-			const onClickHander = () => {
+			const onClickHandler = () => {
 				// For just adding the selected member
 				$('#alert-modal .add-selected-button').click(() => {
 					const climberID = $('#modal-add-route-member').val();
@@ -1223,7 +1223,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				'Select expedition member(s) to add', 
 				'confirm', 
 				footerButtons,
-				{eventHandlerCallable: onClickHander});
+				{eventHandlerCallable: onClickHandler});
 		}
 	} 
 
@@ -1745,7 +1745,7 @@ class ClimberDBExpeditions extends ClimberDB {
 	confirmSaveEdits({afterActionCallback=()=>{}, afterCancelCallback=()=>{}}={}) {
 		//@param afterActionCallbackStr: string of code to be appended to html onclick attribute
 		
-		const onClickHander = () => { 
+		const onClickHandler = () => { 
 			
 			$('#alert-modal .cancel-button').click(() => {
 				afterCancelCallback();
@@ -1777,7 +1777,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			'Save edits?',
 			'alert',
 			footerButtons,
-			{eventHandlerCallable: onClickHander}
+			{eventHandlerCallable: onClickHandler}
 		);
 	}
 

--- a/web/js/users.js
+++ b/web/js/users.js
@@ -514,7 +514,7 @@ class ClimberDBUsers extends ClimberDB {
 	confirmSaveEdits({afterActionCallback=()=>{}, afterCancelCallback=()=>{}}={}) {
 		//@param afterActionCallbackStr: string of code to be appended to html onclick attribute
 		
-		const onClickHander = () => { 
+		const onClickHandler = () => { 
 			
 			$('#alert-modal .cancel-button').click(() => {
 				afterCancelCallback();
@@ -546,7 +546,7 @@ class ClimberDBUsers extends ClimberDB {
 			'Save edits?',
 			'alert',
 			footerButtons,
-			{eventHandlerCallable: onClickHander}
+			{eventHandlerCallable: onClickHandler}
 		);
 	}
 


### PR DESCRIPTION
These changes finally remove all string substitutions for binding `click` events to modal buttons in the `showModal()` function. There are still some references to `climberDB` as opposed to `this`, but I think I can mostly do a find/replace, Related: #85 