### PR TITLE
handle null ranger when saving

### DIFF
--- a/web/js/briefings.js
+++ b/web/js/briefings.js
@@ -611,7 +611,7 @@ class ClimberDBBriefings extends ClimberDB {
 			if (el.id.endsWith('_time')) {
 				values[el.name.replace(/_time$/, '')] = `${briefingDate} ${el.value}`;
 			} else {
-				values[el.name] = el.value;
+				values[el.name] = el.value === '' ? null : el.value;
 			}
 		}
 


### PR DESCRIPTION
The problem here is that SQLAlchemy doesn't automatically convert empty strings to null. For integer fields (e.g., any lookups), SQLAlchemy throws an error when the value is `''`. This fix is just a patch, but I should probably come up with a systemic fix