### PR TITLE
handle int as str for next permit number

### DIFF
--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -1638,7 +1638,7 @@ def get_next_permit_number(year: int) -> str:
 	"""
 	sql = sqlatext(f'''
 		SELECT 
-		max(m.permit_number) AS max_permit 
+		max(substring(m.permit_number, '\\d+$')::INTEGER) AS max_permit  
 		FROM {schema}.expedition_members m
 		JOIN {schema}.expeditions e ON m.expedition_id=e.id
 		WHERE 
@@ -1650,7 +1650,7 @@ def get_next_permit_number(year: int) -> str:
 		row = cursor.first()
 		if row:
 			# Permit format: TKA-YY-####. Just return just the number + 1
-			return str(int((row.max_permit or '0000').split('-')[-1]) + 1)
+			return str((row.max_permit or 0) + 1)
 		else:
 			raise RuntimeError('Failed to get next permit number')
 


### PR DESCRIPTION
The previous query for the max permit number evaluated permit numbers as strings, so `TKA-25-9` was greater than `TKA-25-10`. This meant that as soon as there were 9 records entered in the `expedition_members` table for a given year, `get_next_permit_number()` would always return '10' as the next permit number