### PR TITLE
show exp. name as tooltip on current bc groups map

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -862,8 +862,9 @@ CREATE VIEW current_backcountry_groups_view AS
 	)
 	SELECT 
 	  itinerary_locations.expedition_id, 
+	  expeditions.expedition_name,
 	  latitude, 
-	  longitude 
+	  longitude
 	FROM 
 	  itinerary_locations 
 	    JOIN expeditions ON expeditions.id=itinerary_locations.expedition_id 
@@ -871,7 +872,8 @@ CREATE VIEW current_backcountry_groups_view AS
 	    JOIN today ON today.now BETWEEN coalesce(location_start_date, (today.year || '-1-1')::date) AND coalesce(location_end_date, (today.year || '-12-31')::date)
 	WHERE 
 	  expedition_status = 4 AND 
-	  actual_departure_date < today.now
+	  actual_departure_date < today.now AND 
+	  today.year = extract(year FROM actual_departure_date)
 	;
 
 CREATE MATERIALIZED VIEW table_info_matview AS 

--- a/web/js/backcountry.js
+++ b/web/js/backcountry.js
@@ -338,7 +338,7 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 
 	configureMainContent() {
 		super.configureMainContent();
-		this.configureMap('main-map', this.maps.main);
+		this.configureMap('main-map', {mapObject: this.maps.main});
 
 		// Location handlers
 		$('#add-location-button').click(() => {

--- a/web/js/dashboard.js
+++ b/web/js/dashboard.js
@@ -290,7 +290,7 @@ class ClimberDBDashboard extends ClimberDB {
 			`).appendTo($('#season-mountain-stats-card .mountain-stats-table tbody'))
 		}
 
-		// Query BC stas
+		// Query BC stats
 		const bcSQL = `
 			SELECT
 				group_status_code,
@@ -696,7 +696,7 @@ class ClimberDBDashboard extends ClimberDB {
 
 		const queryDeferred = this.queryDB({tables: ['current_backcountry_groups_view']})
 		return $.when(
-			this.configureMap('bc-groups-map', this.maps.main),
+			this.configureMap('bc-groups-map', {mapObject: this.maps.main, showBackcountryUnits: false}),
 			queryDeferred
 		).done((_, [queryResponse]) => { // ignore .configureMap() response
 			if (this.pythonReturnedError(queryResponse)) {
@@ -711,8 +711,9 @@ class ClimberDBDashboard extends ClimberDB {
 					spiderLegPolylineOptions: {color: '#fff'},
 					showCoverageOnHover: false
 				});
-				for (const {expedition_id, latitude, longitude} of result) {
+				for (const {expedition_id, expedition_name, latitude, longitude} of result) {
 					const marker = L.marker([latitude, longitude], {icon: icon})
+						.bindTooltip(expedition_name)
 						.on('click', () => {
 							// when clicked, open the backcountry page for that group in a new tab
 							window.open(`backcountry.html?id=${expedition_id}`, '_blank')


### PR DESCRIPTION
When you hover over a backcountry group icon on the "Current Backcountry Groups" map of the dashboard, you now see the group name as a tooltip. I'm not sure if this is the best UX to handle the problem, mainly because you still have to hover over each group to figure out which one is which. The alternative would be showing a popup as a label that's always visible, but that could get visually cluttered. I'll keep this for now but I might want to tweak it later