### PR TITLE
handle extra hour/min in date stamps

### DIFF
--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -493,7 +493,7 @@ def get_confirmation_letter(expedition_id):
 	data['climbers'] = json.loads(data['climbers'])
 	# Reformat date to be more human-readable
 	data['planned_departure_date'] = datetime.strptime(
-			data['planned_departure_date'], '%Y-%m-%d'
+			data['planned_departure_date'], '%Y-%m-%d %H:%M'
 		).strftime('%B %#d, %Y')
 	
 	# Get HTML string


### PR DESCRIPTION
Changed the formatting of date stamps passed back in responses with PR #72. Just needed to update the string formatting when date stamp with 00:00 time is passed back in the confirmation letter request.