### PR TITLE
Fix expedition meta field display

### DIFF
--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -1396,13 +1396,22 @@ class ClimberDBExpeditions extends ClimberDB {
 				dbInserts.expeditions = [{
 					values: {
 						is_backcountry: !!window.location.pathname.match('backcountry.html'), 
+						entered_by: username,
+						entry_time: now,
+						last_modified_by: username,
+						last_modified_time: now,
 						...expeditionEdits
 					},
 					html_id: 'input-expedition_name',
 					children: {}
 				}];
 			} else {
-				dbUpdates.expeditions = {[expeditionID]: expeditionEdits}; 
+				dbUpdates.expeditions = {[expeditionID]: {
+						...expeditionEdits,
+						last_modified_by: username,
+						last_modified_time: now
+					}
+				}; 
 				dbInserts.expeditions = [
 					{
 						id: expeditionID,


### PR DESCRIPTION
I added values for meta fields for all tables except expeditions. Also `expedition_info_view` was displaying `entry_time` and `entered_by` for `last_modified_time` and `last_modified_by` fields. As a convenience, I also changed all `CREATE VIEW` calls in `create_db.sql` to `CREATE OR REPLACE` so that when I copy and paste, I don't have to explicitly `DROP` it first.