### PR TITLE
Add admin error notifications

### DIFF
--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -65,6 +65,92 @@ log_dir = os.path.join(os.path.dirname(__file__), 'logs')
 if not os.path.isdir(log_dir):
 	os.mkdir(log_dir)
 
+class RequestLoggingFormatter(logging.Formatter):
+	"""
+	Configure a custom formatter to include request information
+	"""
+	def format(self, record):
+		if has_request_context():
+			record.url = request.url
+			record.remote_addr = request.remote_addr
+			record.user = request.remote_user
+			record.request_data = (
+				'**ommitted**' if request.url.endswith('checkPassword') else 
+				json.dumps(request.form)
+			)
+		else:
+			record.url = None
+			record.remote_addr = None
+			record.user = None
+			record.request_data = None
+		return super().format(record)
+
+
+def configure_logging(app_name, log_dir):
+
+
+	with open(climberdb_utils.CONFIG_FILE) as f:
+		app_config = json.load(f)
+
+	environment = climberdb_utils.get_environment()
+	logging_config = {
+		'version': 1,
+		'formatters': {
+			'default': {
+				'datefmt': '%B %d, %Y %H:%M:%S %Z',
+			},
+		},
+		'handlers': {
+			# Configure a logger that will create a new file each day
+			#	Only 100 logs will be saved before they oldest one is deleted
+			'file': {
+				'class': 'logging.handlers.TimedRotatingFileHandler',
+				'filename': os.path.join(log_dir, 'flask.log'),
+				'when': 'D',
+				'interval': 1,
+				'backupCount': 100,
+				'formatter': 'default',
+				'level': 'INFO'
+			},
+			# Logger for email notifications of Python errors
+			'email': {
+				'class': 	'logging.handlers.SMTPHandler',
+				'level': 	'ERROR',
+				'mailhost': app_config['MAIL_SERVER'],
+				'fromaddr': f'ClimberDB Error Notifications <{app_name}.{environment}-notifications@nps.gov>',
+				'toaddrs':	[app_config['DB_ADMIN_EMAIL']],
+				'subject':	f'An error occurred with the {app_name} app'
+			}
+		},
+		'root': {
+			'level': 'INFO',
+			'handlers': ['file', 'email'],
+		}
+	}
+
+	dictConfig(logging_config)
+
+	line_separator = '-' * 150 
+	file_formatter = RequestLoggingFormatter(line_separator + 
+	    '\n[%(asctime)s] %(user)s requested %(url)s from %(remote_addr)s\n' 
+	    'with POST data %(request_data)s\n'
+	    '%(levelname)s in %(module)s message:\n %(message)s\n' +
+	    line_separator
+	)
+
+	email_formatter = RequestLoggingFormatter(
+		'Time: %(asctime)s\n'
+		'User: %(user)s\n'
+		'URL: %(url)s\n'
+		'Remote Address: %(remote_addr)s\n'
+		'Logger name: %(name)s\n'
+		'\n'
+	)
+
+	root_logger = logging.root
+	root_logger.handlers[0].setFormatter(file_formatter) # file
+	root_logger.handlers[1].setFormatter(email_formatter) # email
+	
 
 # Configure logging before initializing the Flask instance because Flask will 
 #	otherwise create its own default_logger if a logger doesn't already exist

--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -188,6 +188,14 @@ if not app.config.from_file(climberdb_utils.CONFIG_FILE, load=json.load):
 	raise IOError(f'Could not read CONFIG_FILE: {climberdb_utils.CONFIG_FILE}')
 
 
+@app.route('/flask/test/error', methods=['POST'])
+def test_error_logging() -> bool:
+	data = request.form
+	if data.get('test_client_secret') == app.config['TEST_CLIENT_SECRET']:
+		raise IOError('test error')
+
+	return True
+
 @app.route('/flask/environment', methods=['GET'])
 def get_environment() -> str:
 	return climberdb_utils.get_environment()

--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -150,7 +150,7 @@ def configure_logging(app_name, log_dir):
 	root_logger = logging.root
 	root_logger.handlers[0].setFormatter(file_formatter) # file
 	root_logger.handlers[1].setFormatter(email_formatter) # email
-	
+
 
 # Configure logging before initializing the Flask instance because Flask will 
 #	otherwise create its own default_logger if a logger doesn't already exist
@@ -1618,8 +1618,6 @@ def save_config():
 
 @app.route('/flask/db/delete/by_id', methods=['POST'])
 def delete_by_id():
-
-	raise ValueError('test error')
 
 	request_data = request.get_json()
 

--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -93,6 +93,17 @@ def configure_logging(app_name, log_dir):
 		app_config = json.load(f)
 
 	environment = climberdb_utils.get_environment()
+	
+	# If the config file doesn't have a specific property set for error notification 
+	#	recipients, just send them to the DB admin
+	error_recipients = (
+		app_config.get('ERROR_NOTIFICATION_RECIPIENTS') or 
+		app_config.get('DB_ADMIN_EMAIL')
+	)
+	# And since the recipients could be a string or list, make sure it's a list
+	if not isinstance(error_recipients, list):
+		error_recipients = str(error_recipients).split(',')
+	
 	logging_config = {
 		'version': 1,
 		'formatters': {
@@ -118,7 +129,7 @@ def configure_logging(app_name, log_dir):
 				'level': 	'ERROR',
 				'mailhost': app_config['MAIL_SERVER'],
 				'fromaddr': f'ClimberDB Error Notifications <{app_name}.{environment}-notifications@nps.gov>',
-				'toaddrs':	[app_config['DB_ADMIN_EMAIL']],
+				'toaddrs':	error_recipients,
 				'subject':	f'An error occurred with the {app_name} app'
 			}
 		},

--- a/web/flask/climberdb_logging.py
+++ b/web/flask/climberdb_logging.py
@@ -1,0 +1,94 @@
+import json
+import logging
+from logging.config import dictConfig
+import os
+
+import climberdb_utils
+
+
+class RequestLoggingFormatter(logging.Formatter):
+	"""
+	Configure a custom formatter to include request information
+	"""
+	def format(self, record):
+		if has_request_context():
+			record.url = request.url
+			record.remote_addr = request.remote_addr
+			record.user = request.remote_user
+			record.request_data = (
+				'**ommitted**' if request.url.endswith('checkPassword') else 
+				json.dumps(request.form)
+			)
+		else:
+			record.url = None
+			record.remote_addr = None
+			record.user = None
+			record.request_data = None
+		return super().format(record)
+
+
+def configure_logging(app_name, log_dir):
+
+
+	with open(climberdb_utils.CONFIG_FILE) as f:
+		app_config = json.load(f)
+
+	environment = climberdb_utils.get_environment()
+	logging_config = {
+		'version': 1,
+		'formatters': {
+			'default': {
+				'datefmt': '%B %d, %Y %H:%M:%S %Z',
+			},
+		},
+		'handlers': {
+			# Configure a logger that will create a new file each day
+			#	Only 100 logs will be saved before they oldest one is deleted
+			'file': {
+				'class': 'logging.handlers.TimedRotatingFileHandler',
+				'filename': os.path.join(log_dir, 'flask.log'),
+				'when': 'D',
+				'interval': 1,
+				'backupCount': 100,
+				'formatter': 'default',
+				'level': 'INFO'
+			},
+			# Logger for email notifications of Python errors
+			'email': {
+				'class': 	'logging.handlers.SMTPHandler',
+				'level': 	'ERROR',
+				'mailhost': app_config['MAIL_SERVER'],
+				'fromaddr': f'ClimberDB Error Notifications <{app_name}.{environment}-notifications@nps.gov>',
+				'toaddrs':	[app_config['DB_ADMIN_EMAIL']],
+				'subject':	f'An error occurred with the {app_name} app'
+			}
+		},
+		'root': {
+			'level': 'INFO',
+			'handlers': ['file', 'email'],
+		}
+	}
+
+	dictConfig(logging_config)
+
+	line_separator = '-' * 150 
+	file_formatter = RequestLoggingFormatter(line_separator + 
+	    '\n[%(asctime)s] %(user)s requested %(url)s from %(remote_addr)s\n' 
+	    'with POST data %(request_data)s\n'
+	    '%(levelname)s in %(module)s message:\n %(message)s\n' +
+	    line_separator
+	)
+
+	email_formatter = RequestLoggingFormatter(
+		'Time: %(asctime)s\n'
+		'User: %(user)s\n'
+		'URL: %(url)s\n'
+		'Remote Address: %(remote_addr)s\n'
+		'Logger name: %(name)s\n'
+		'\n'
+	)
+
+	root_logger = logging.root
+	root_logger.handlers[0].setFormatter(file_formatter) # file
+	root_logger.handlers[1].setFormatter(email_formatter) # email
+

--- a/web/js/backcountry.js
+++ b/web/js/backcountry.js
@@ -243,7 +243,7 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 			const footerButtons = 
 				'<button class="generic-button modal-button close-modal danger-button confirm-button" data-dismiss="modal">Yes</button>' + 
 				'<button class="generic-button secondary-button modal-button close-modal deny-button" data-dismiss="modal">No</button>'
-			showModal(message, 'Reset Location coordinates?', 'alert', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
+			this.showModal(message, 'Reset Location coordinates?', 'alert', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
 		} else {
 			$latitudeField.val(latitude).addClass('dirty');
 			$longitudeField.val(longitude).change();
@@ -412,15 +412,13 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 					tables: ['backcountry_location_codes'], 
 					order_by: [{table_name: 'backcountry_location_codes', column_name: 'sort_order'}]
 				}).done(result => {
-					if (this.pythonReturnedError(result, {errorExplanation: 'An error occurred while retrieving lookup values from the database.'})) {
-						//showModal('An error occurred while retrieving lookup values from the database: ' + result, 'Database Error');
-						return;
-					}
-					for (const {code, name, latitude, longitude} of result.data) {
-						this.locationCoordinates[code] = {
-							name: name,
-							latitude: latitude, 
-							longitude: longitude
+					if (!this.pythonReturnedError(result, {errorExplanation: 'An error occurred while retrieving lookup values from the database.'})) {
+						for (const {code, name, latitude, longitude} of result.data) {
+							this.locationCoordinates[code] = {
+								name: name,
+								latitude: latitude, 
+								longitude: longitude
+							}
 						}
 					}
 				})

--- a/web/js/backcountry.js
+++ b/web/js/backcountry.js
@@ -412,8 +412,8 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 					tables: ['backcountry_location_codes'], 
 					order_by: [{table_name: 'backcountry_location_codes', column_name: 'sort_order'}]
 				}).done(result => {
-					if (this.pythonReturnedError(result)) {
-						showModal('An error occurred while retrieving lookup values from the database: ' + result, 'Database Error');
+					if (this.pythonReturnedError(result, {errorExplanation: 'An error occurred while retrieving lookup values from the database.'})) {
+						//showModal('An error occurred while retrieving lookup values from the database: ' + result, 'Database Error');
 						return;
 					}
 					for (const {code, name, latitude, longitude} of result.data) {

--- a/web/js/briefings.js
+++ b/web/js/briefings.js
@@ -661,12 +661,8 @@ class ClimberDBBriefings extends ClimberDB {
 			contentType: false,
 			processData: false
 		}).done(response => {
-			if (this.pythonReturnedError(response)) {
-				const message = 'An unexpected error occurred while saving data to the database:' + 
-					' Make sure you\'re still connected to the NPS network and try again.' +
-					` <a href="mailto:${this.config.db_admin_email}">Contact your database` +
-					` adminstrator</a> if the problem persists. Full error: <br><br>${response}`
-				showModal(message, 'Unexpected error');
+			const errorMessage = 'An unexpected error occurred while saving data to the database.';
+			if (this.pythonReturnedError(response, {errorExplanation: errorMessage})) {
 				return;
 			} else {
 				const result = response.data || [];
@@ -718,8 +714,8 @@ class ClimberDBBriefings extends ClimberDB {
 		}).fail((xhr, status, error) => {
 			showModal(
 				`An unexpected error occurred while saving data to the database: ${error}.` + 
-					` Make sure you're still connected to the NPS network and try again. Contact your database` + 
-					` adminstrator if the problem persists.`, 
+					` Make sure you're still connected to the NPS network and try again. ` + 
+					this.getBriefingDateFromURL(), 
 				'Unexpected error'
 			);
 		}).always(() => {
@@ -866,12 +862,13 @@ class ClimberDBBriefings extends ClimberDB {
 			}
 			this.deleteByID('briefings', briefingID, deleteOptions)
 				.done(response => {
-					if (this.pythonReturnedError(response)) {
-						showModal('An error occurred while deleting the briefing. Try again and if this problem persists, contact IT for assistance. Full error message: <br><br>' + response, 'Unexpected Error')
+					const errorMessage = 'An error occurred while deleting the briefing.'
+					if (this.pythonReturnedError(response, {errorExplanation: errorMessage})) {
+						return;
 					} else {
 						const result = response.data || {};
 						if (Object.keys(result).length === 0) {
-							showModal('An error occurred while deleting the briefing. Reload the page and try again. If this problem persists, contact IT for assistance');
+							showModal(message, 'Record Does Not Exist in Database');
 							return;
 						}
 
@@ -1552,8 +1549,9 @@ class ClimberDBBriefings extends ClimberDB {
 			,
 			$.post({url: '/flask/db/select/rangers'})
 				.done(response => {
-					if (this.pythonReturnedError(response)) {
-						showModal('An unexpected error occurred while retreiving briefing details: <br><br>' + response, 'Unexpected Error')
+					const errorMessage = 'An unexpected error occurred while retrieving briefing details.';
+					if (this.pythonReturnedError(response, {errorExplanation: errorMessage})) {
+						return;
 					} else {
 						const rangers = response.data || [];
 						const $input = $('#input-ranger');
@@ -1659,8 +1657,9 @@ class ClimberDBBriefings extends ClimberDB {
 				briefings: JSON.stringify(exportData.briefings)
 			}
 		}).done(resultString => {
+			const errorMessage = 'An unexpected error occurred while exporting the briefing schedule.';
 			if (this.pythonReturnedError(resultString)) {
-				showModal('An unexpected error occurred while exporting the briefing schedule: ' + resultString, 'Export Error')
+				return;
 			} else {
 				window.location.href = resultString;
 			}

--- a/web/js/briefings.js
+++ b/web/js/briefings.js
@@ -589,7 +589,7 @@ class ClimberDBBriefings extends ClimberDB {
 		showLoadingIndicator('saveEdits');
 
 		if (!$('.appointment-details-drawer .input-field.dirty').length) {
-			showModal('You have not made any edits to save yet.', 'No edits to save');
+			this.showModal('You have not made any edits to save yet.', 'No edits to save');
 			hideLoadingIndicator();
 			return;
 		}
@@ -599,7 +599,7 @@ class ClimberDBBriefings extends ClimberDB {
 				const $input = $(el);
 				const labelText = $input.siblings('.field-label').text();
 				$input.addClass('error').focus();
-				showModal(`Before you can save this briefing, all fields except "Briefing ranger" must be filled in and the '${labelText}' field is blank. Fill in this and any other blank fields, then try to save your changes.`, 'Empty field');
+				this.showModal(`Before you can save this briefing, all fields except "Briefing ranger" must be filled in and the '${labelText}' field is blank. Fill in this and any other blank fields, then try to save your changes.`, 'Empty field');
 				hideLoadingIndicator();
 				return;
 			}
@@ -712,7 +712,7 @@ class ClimberDBBriefings extends ClimberDB {
 
 			}
 		}).fail((xhr, status, error) => {
-			showModal(
+			this.showModal(
 				`An unexpected error occurred while saving data to the database: ${error}.` + 
 					` Make sure you're still connected to the NPS network and try again. ` + 
 					this.getBriefingDateFromURL(), 
@@ -782,7 +782,7 @@ class ClimberDBBriefings extends ClimberDB {
 				});
 			})
 		}
-		showModal(
+		this.showModal(
 			'You have unsaved edits to this briefing. Would you like to <strong>Save</strong> or <strong>Discard</strong> them? Click <strong>Cancel</strong> to continue editing this briefing.',
 			'Save edits?',
 			'confirm',
@@ -868,7 +868,7 @@ class ClimberDBBriefings extends ClimberDB {
 					} else {
 						const result = response.data || {};
 						if (Object.keys(result).length === 0) {
-							showModal(message, 'Record Does Not Exist in Database');
+							this.showModal(message, 'Record Does Not Exist in Database');
 							return;
 						}
 
@@ -920,7 +920,7 @@ class ClimberDBBriefings extends ClimberDB {
 			}
 			const expeditionNameText = briefingInfo ? ` for <strong>${briefingInfo.expedition_name}</strong>` : '';
 			const message = `Are you sure you want to delete ${briefingStart ? 'the ' : 'this'}<strong>${briefingStart}</strong> briefing${expeditionNameText}? This action is permanent and <strong>cannot be undone</strong>.`
-			showModal(
+			this.showModal(
 				message,
 				'Delete This Briefing?',
 				'alert',
@@ -1027,7 +1027,7 @@ class ClimberDBBriefings extends ClimberDB {
 							` to ${thisEndDatetime.toLocaleTimeString('en-us', {hour: 'numeric', minute: 'numeric'})}` + 
 							` with ${nClimbersScheduled} total climbers. The maximum number of climbers allowed in` + 
 							` a briefing is ${this.config.max_people_per_briefing}` ;
-						showModal(message, 'Scheduling conflict');
+						this.showModal(message, 'Scheduling conflict');
 						isAvailable = false;
 						break;
 					}
@@ -1039,7 +1039,7 @@ class ClimberDBBriefings extends ClimberDB {
 						thisStartDatetime.toLocaleTimeString('en-us', {hour: 'numeric', minute: 'numeric'}) + 
 						` to ${thisEndDatetime.toLocaleTimeString('en-us', {hour: 'numeric', minute: 'numeric'})}.` + 
 						` Briefings by the same ranger must either start at the same time or not overlap at all.` ;
-					showModal(message, 'Scheduling conflict');
+					this.showModal(message, 'Scheduling conflict');
 					isAvailable = false;
 					break;
 				}
@@ -1163,7 +1163,7 @@ class ClimberDBBriefings extends ClimberDB {
 		//	because if it's the begining the briefing will just be bumped up or down
 		if (!targetIsStartTime && newStartTime.padStart(5, '0') >= endTime.padStart(5, '0')) {
 			const message = `The briefing start time must be before the end time. The start time is currently set to <strong>${newStartTime}</strong> but the end time you selected is <strong>${endTime}</strong>.`;
-			showModal(message, 'Invalid Briefing End Time');
+			this.showModal(message, 'Invalid Briefing End Time');
 			this.revertInputValue($target, {briefingInfo: info});
 			return;
 		}
@@ -1664,7 +1664,7 @@ class ClimberDBBriefings extends ClimberDB {
 				window.location.href = resultString;
 			}
 		}).fail((xhr, status, error) => {
-			showModal('An unexpected error occurred while exporting the briefing schedule: ' + error)
+			this.showModal('An unexpected error occurred while exporting the briefing schedule: ' + error)
 		}).always(() => {hideLoadingIndicator()})
 
 	}
@@ -1684,7 +1684,7 @@ class ClimberDBBriefings extends ClimberDB {
 		if (rangeLengthDays > 366) {
 			const message = 'You entered a date range of more than one year. Change either' + 
 				' the start or the end date so that the total range is less than one year.'
-			showModal(message, 'Date Range Too Large');
+			this.showModal(message, 'Date Range Too Large');
 			return;
 		}
 

--- a/web/js/climberdb.js
+++ b/web/js/climberdb.js
@@ -401,8 +401,8 @@ class ClimberDB {
 		return $.post({
 			url: '/flask/config'
 		}).done(response => {
-			if (this.pythonReturnedError(response)) {
-				showModal('Invalid Configuration', 'There was a problem retrieving the app configuration: ' + response);
+			if (this.pythonReturnedError(response, {errorExplanation: 'There was a problem retrieving the app configuration.'})) {
+				return;
 			} else {
 				this.config = {...response}
 			}
@@ -1530,6 +1530,13 @@ class ClimberDB {
 	}
 
 
+	getDBContactMessage() {
+		return ' Make sure you\'re still connected to the NPS network and try again.' +
+			` <a href="mailto:${this.config.db_admin_email}">Contact your database` +
+			' adminstrator</a> if the problem persists.';
+	}
+
+
 	pythonReturnedError(resultString, {errorExplanation=''}={}) {
 		resultString = String(resultString); // force as string in case it's something else
 		if (resultString.startsWith('ERROR: Internal Server Error')) {
@@ -1538,10 +1545,11 @@ class ClimberDB {
 			const pythonException = (resultString.match(/[A-Z]+[a-zA-Z]*Error: .*/) || ['unknown custom exception thrown']
 			)[0].trim();
 			
+			const dbContact = this.getDBContactMessage();
 			// Show the 
 			if (errorExplanation !== '') {
 				const messageBody = `
-					${errorExplanation}  
+					${errorExplanation}${dbContact} 
 					<div class="w-100 d-flex justify-content-between">
 						<button 
 							role="button"
@@ -1579,7 +1587,7 @@ class ClimberDB {
 			.closest('.modal-body')
 			.find('.modal-error-text-container')
 			.text();
-		this.copyToClipboard(error, {triggeringElement: $button})
+		this.copyToClipboard(error, {triggeringElement: $button, tooltipContainer: '#alert-modal'})
 	}
 
 

--- a/web/js/climberdb.js
+++ b/web/js/climberdb.js
@@ -1568,7 +1568,7 @@ class ClimberDB {
 							Copy error text
 						</button>
 					</div>
-					<p id="modal-error-details-collapse" class="collapse modal-error-details-target modal-error-text-container">
+					<p id="modal-error-details-collapse" class="collapse modal-error-details-target modal-error-text-container pt-3">
 						${resultString}
 					</p>`;
 				showModal(messageBody, 'Unexpected Error');

--- a/web/js/climbers.js
+++ b/web/js/climbers.js
@@ -743,8 +743,8 @@ class ClimberForm {
 		if (!dob || dob === $dobField.data('current-value')) return;
 
 		const birthdate = new Date(dob + ' 00:00');
-		const calculatedAge = Math.floor((new Date() - birthdate) / climberDB.constants.millisecondsPerDay / 365)
-		const enteredAge = $ageField.val()
+		const calculatedAge = Math.floor((new Date() - birthdate) / (this.constants || this._parent.constants).millisecondsPerDay / 365);
+		const enteredAge = $ageField.val();
 		if (enteredAge && enteredAge != calculatedAge) {
 			const message = `You changed this climber's D.O.B. to a date that conflicts with the currently entered age. Would you like to update the climber's age to ${calculatedAge}?`;
 			const footerButtons = 
@@ -755,9 +755,15 @@ class ClimberForm {
 					$ageField.val(calculatedAge).change();
 				})
 			}
-			showModal(message, 'Update Climber Age?', 'confirm', footerButtons, {eventHandlerCallable: eventHandler})
+			const modalArgs = {
+				modalType: 'confirm', 
+				footerButtons: footerButtons, 
+				eventHandlerCallable: eventHandler, 
+				modalMessageQueue: this._parent.modalMessageQueue
+			}
+			this._parent.showModal(message, 'Update Climber Age?', modalArgs);
 		} else {
-			$ageField.val(calculatedAge).change()
+			$ageField.val(calculatedAge).change();
 		}
 
 	}
@@ -778,12 +784,12 @@ class ClimberForm {
 		if (!dob || !age) return;
 
 		const birthdate = new Date(dob + ' 00:00');
-		const calculatedAge = Math.floor((new Date() - birthdate) / this.constants.millisecondsPerDay / 365);
+		const calculatedAge = Math.floor((new Date() - birthdate) / (this.constants || this._parent.constants).millisecondsPerDay / 365);
 		const enteredAge = $ageField.val();
 
 		if (calculatedAge != enteredAge) {
 			const message = `You entered this climber's age as ${enteredAge}, but this conflicts with the climber's D.O.B. Make sure the data you've entered in both of these fields is correct.`;
-			showModal(message, 'WARNING: Age Conflicts with D.O.B.');
+			this._parent.showModal(message, 'WARNING: Age Conflicts with D.O.B.', {modalMessageQueue: this._parent.modalMessageQueue});
 		}
 
 	}
@@ -857,7 +863,13 @@ class ClimberForm {
 					`You've made changes to the cliimber form. Are you sure you want to close` + 
 					' the form and discard these edits? To continue editing or save your edits, click cancel.';
 				const eventHandler = () => ($('#alert-modal .discard-button').click(() => {afterCloseCallBack.call()}))
-				showModal(message, 'Discard climber edits?', 'confirm', footerButtons, {eventHandlerCallable: eventHandler})
+				const modalArgs = {
+					modalType: 'confirm', 
+					footerButtons: footerButtons, 
+					eventHandlerCallable: eventHandler,
+					modalMessageQueue: this._parent.modalMessageQueue
+				}
+				this._parent.showModal(message, 'Discard climber edits?', modalArgs);
 			} else {
 				// User can save, discard, or cancel
 				this.confirmSaveEdits(afterCloseCallBack);
@@ -1011,7 +1023,7 @@ class ClimberForm {
 					}
 				}
 			}).fail((xhr, status, error) => {
-				showModal('Retrieving climber history from the database failed because ' + error, 'Database Error')
+				this._parent.showModal('Retrieving climber history from the database failed because ' + error, 'Database Error')
 			});
 
 		}
@@ -1062,7 +1074,7 @@ class ClimberForm {
 				}
 			})
 			.fail((xhr, status, error) => {
-				showModal('Retrieving climber history from the database failed.' + this._parent.getDBContactMessage(), 'Database Error')
+				this._parent.showModal('Retrieving climber history from the database failed.' + this._parent.getDBContactMessage(), 'Database Error')
 			});
 
 		const contactsDeferred = this._parent.queryDB({
@@ -1077,7 +1089,7 @@ class ClimberForm {
 				}
 			})
 			.fail((xhr, status, error) => {
-				showModal('Retrieving emergency contact info from the database failed.' + this._parent.getDBContactMessage(), 'Database Error')
+				this._parent.showModal('Retrieving emergency contact info from the database failed.' + this._parent.getDBContactMessage(), 'Database Error')
 			});
 
 
@@ -1128,7 +1140,7 @@ class ClimberForm {
 		
 		const inputSelector = '.input-field.dirty';
 		if ($(inputSelector).length === 0) {
-			showModal("You have not made any edits to save yet. Add or change this climber's information and then try to save it.", "No edits to save");
+			this._parent.showModal("You have not made any edits to save yet. Add or change this climber's information and then try to save it.", "No Edits To Save");
 			return $.Deferred().resolve('');
 		}
 
@@ -1149,7 +1161,7 @@ class ClimberForm {
 			if (requiredFieldsDisabled) message += 
 				' Even though you disabled required fields,' + 
 				' first and last name are always required.'
-			showModal(message, 'Required Field Is Empty');
+			this._parent.showModal(message, 'Required Field Is Empty');
 			return;
 		};
 
@@ -1275,7 +1287,7 @@ class ClimberForm {
 				this._parent.toggleBeforeUnload(false);
 			}
 		}).fail((xhr, status, error) => {
-			showModal(`An unexpected error occurred while saving data to the database: ${error}. Make sure you're still connected to the NPS network and try again. Contact your database adminstrator if the problem persists.`, 'Unexpected error');
+			this._parent.showModal(`An unexpected error occurred while saving data to the database: ${error}.${this._parent.getDBContactMessage()}`, 'Unexpected error');
 		}).always(() => {
 			this._parent.hideLoadingIndicator();
 		});
@@ -1311,12 +1323,15 @@ class ClimberForm {
 		// climberDB is a global instance of ClimberDB or its subclasses that should be instantiated in each page
 		// 	this is a little un-kosher because the ClimberForm() instance is probably a property of climberDB, but
 		//	the only alternative is to make showModal a global function 
-		showModal(
+		this._parent.showModal(
 			`You have unsaved edits to this climber. Would you like to <strong>Save</strong> or <strong>Discard</strong> them? Click <strong>Cancel</strong> to continue editing this climber's info.`,
 			'Save edits?',
-			'alert',
-			footerButtons,
-			{eventHandlerCallable: eventHandler}
+			{
+				modalType: 'alert',
+				footerButtons: footerButtons,
+				eventHandlerCallable: eventHandler,
+				modalMessageQueue: this._parent.modalMessageQueue
+			}
 		);
 	}
 
@@ -1348,7 +1363,7 @@ class ClimberForm {
 						$card.fadeOut(500, () => {$card.remove()});
 					}
 				}).fail((xhr, status, error) => {
-					showModal(`An unexpected error occurred while deleting data from the database: ${error}.${this._parent.getDBContactMessage()}`, 'Unexpected error');
+					this._parent.showModal(`An unexpected error occurred while deleting data from the database: ${error}.${this._parent.getDBContactMessage()}`, 'Unexpected error');
 				}).always(() => {
 					hideLoadingIndicator();
 				});
@@ -1372,7 +1387,16 @@ class ClimberForm {
 			<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">No</button>
 			<button class="generic-button modal-button confirm-button danger-button close-modal" data-dismiss="modal">Yes</button>
 		`;
-		showModal(`Are you sure you want to delete this ${itemName}?`, `Delete ${itemName}?`, 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
+		this._parent.showModal(
+			`Are you sure you want to delete this ${itemName}?`, 
+			`Delete ${itemName}?`, 
+			{
+				modalType: 'confirm', 
+				footerButtons: footerButtons, 
+				eventHandlerCallable: onConfirmClickHandler,
+				modalMessageQueue: this._parent.modalMessageQueue
+			}
+		);
 
 	}
 
@@ -1385,7 +1409,7 @@ class ClimberForm {
 					return;
 				} 
 			}).fail((xhr, status, error) => {
-				showModal(`An unexpected error occurred while deleting data from the database: ${error}. Make sure you're still connected to the NPS network and try again. Contact your database adminstrator if the problem persists.`, 'Unexpected error');
+				this._parent.showModal(`An unexpected error occurred while deleting data from the database: ${error}.${this._parent.getDBContactMessage()}`, 'Unexpected error');
 			}).always(() => {
 				hideLoadingIndicator();
 			});
@@ -1715,7 +1739,12 @@ class ClimberDBClimbers extends ClimberDB {
 							() => {this.saveModalClimber()}
 						)
 					}
-					showModal(message, 'Possible Duplicate Climber', 'confirm', footerButtons, {eventHandlerCallable: onConfirmClick});
+					const modalArgs = {
+						modalType: 'confirm', 
+						footerButtons: footerButtons, 
+						eventHandlerCallable: onConfirmClick
+					}
+					this.showModal(message, 'Possible Duplicate Climber', modalArgs);
 				} else {
 					this.saveModalClimber();
 				}
@@ -2005,7 +2034,7 @@ class ClimberDBClimbers extends ClimberDB {
 					$('.hidden-on-invalid-result').ariaHide(true);
 					$('.result-details-pane').addClass('collapsed');
 				} else if (response.match(`No climber with ID ${climberID} found`)){ 
-					showModal(
+					this.showModal(
 						`There is no climber with the database ID '${climberID}'. This climber was either deleted or the URL you are trying to use is invalid.`, 
 						'Invalid Climber ID'
 					);
@@ -2013,7 +2042,7 @@ class ClimberDBClimbers extends ClimberDB {
 					this.resetURL();
 					this.getResultSet({newHistoryEntry: false});
 				} else {
-					showModal('Retrieving climber info from the database failed with the following error: <br>' + response, 'Database Error');
+					this.showModal('Retrieving climber info from the database failed with the following error: <br>' + response, 'Database Error');
 				}
 			} else {  
 				var result = response.data || [];
@@ -2070,7 +2099,7 @@ class ClimberDBClimbers extends ClimberDB {
 				
 			}
 		}).fail((xhr, status, error) => {
-			showModal('Retrieving climber info from the database failed because ' + error, 'Database Error')
+			this.showModal('Retrieving climber info from the database failed because ' + error, 'Database Error')
 		})
 	}
 
@@ -2153,7 +2182,7 @@ class ClimberDBClimbers extends ClimberDB {
 		// If this isn't an admin, check if the climber belongs to any expeditions
 		if (!this.userInfo.isAdmin) {
 			if (climberInfo.expedition_name) { // will be null if climber isn't/wasn't on any expeditions
-				showModal(
+				this.showModal(
 					`You can't delete ${climberInfo.first_name} ${climberInfo.last_name}'s climber profile` + 
 						' because they are a member of at least one expedition. You must remove them from all' + 
 						' expeditions they\'re a member of before their profile can be deleted.', 
@@ -2178,7 +2207,12 @@ class ClimberDBClimbers extends ClimberDB {
 			message += ' and all information about their climbs will be delete including transaction history,' + 
 				' medical issues, and whether or not they summited.';
 		}
-		showModal(message, `Delete climber?`, 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
+		const modalArgs = {
+			modalType: 'confirm', 
+			footerButtons: footerButtons, 
+			eventHandlerCallable: onConfirmClickHandler
+		}
+		this.showModal(message, `Delete climber?`, modalArgs);
 	}
 
 
@@ -2309,7 +2343,7 @@ class ClimberDBClimbers extends ClimberDB {
 					.fail((xhr, status, error) => {
 						const message = 'Retrieving climber history from the database' + 
 							` failed with the error ${error}.${this.getDBContactMessage()}`;
-						showModal(message, 'Database Error')
+						this.showModal(message, 'Database Error')
 					});
 				} else {
 					console.log('No climber found with ID ' + ClimberID);
@@ -2337,7 +2371,7 @@ class ClimberDBClimbers extends ClimberDB {
 		// Check that the user has actually selected a climber. This shouldn't be necessary beceause
 		//	 the button should only be visible if a climber *is* selected, but just in case...
 		if (!mergeClimberID) {
-			showModal(`You must select a climber to merge with ${selectedClimberName}`, 'Invalid Operation');
+			this.showModal(`You must select a climber to merge with ${selectedClimberName}`, 'Invalid Operation');
 		}
 
 		// Same buttons for either deleting an empty climber profile or merging
@@ -2367,7 +2401,12 @@ class ClimberDBClimbers extends ClimberDB {
 					});
 				});
 			}
-			showModal(message, 'Premanently Delete Climber Profile?', 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
+			const modalArgs = {
+				modalType: 'confirm', 
+				footerButtons: footerButtons, 
+				eventHandlerCallable: onConfirmClickHandler
+			}
+			this.showModal(message, 'Premanently Delete Climber Profile?', modalArgs);
 			return;
 		}
 
@@ -2395,7 +2434,7 @@ class ClimberDBClimbers extends ClimberDB {
 						` profile to <strong>${selectedClimberName}'s</strong>.`;
 						// Between dismissing the confirmation modal and showing this one, wires are getting 
 						//	crossed so pause for a half second before showing this one
-						setTimeout(()=>{showModal(message, 'Climber Profiles Succesfully Merged')}, 500);
+						setTimeout(()=>{this.showModal(message, 'Climber Profiles Succesfully Merged')}, 500);
 						
 						// Reload the currently selected climber by either 
 						const maxIndex = this.currentRecordSetIndex * this.recordsPerSet;
@@ -2410,18 +2449,22 @@ class ClimberDBClimbers extends ClimberDB {
 						// Hide the details because the selected climber to merge should no longer exist
 						$('.merge-climber-details-container').collapse('hide');
 					} else {
-						showModal('An unkown error occurred while trying to merge climber profiles.' + this.getDBContactMessage(), 'Unexpected Error');
+						this.showModal('An unkown error occurred while trying to merge climber profiles.' + this.getDBContactMessage(), 'Unexpected Error');
 					}
 				}).fail((xhr, status, error) => {
 					const message = 
 						'An error occurred while trying to merge climber' + 
 						` profiles: ${error}.${this.getDBContactMessage()}`;
-					showModal(message, 'Unexpected Error');
+					this.showModal(message, 'Unexpected Error');
 				}).always(() => {hideLoadingIndicator()})
 			})
 		}
-		
-		showModal(message, 'Confirm Climber Profile Merge', 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
+		const modalArgs = {
+			modalType: 'confirm', 
+			footerButtons: footerButtons, 
+			eventHandlerCallable: onConfirmClickHandler
+		}
+		this.showModal(message, 'Confirm Climber Profile Merge', modalArgs);
 	}
 
 

--- a/web/js/config.js
+++ b/web/js/config.js
@@ -121,12 +121,13 @@ class ClimberDBConfig extends ClimberDB {
 			<button class="generic-button modal-button danger-button discard-button close-modal" data-dismiss="modal">Discard</button>
 			<button class="generic-button modal-button primary-button confirm-button close-modal" data-dismiss="modal">Save</button>
 		`;
-		showModal(
+		this.showModal(
 			'You have unsaved edits. Would you like to <strong>Save</strong> or <strong>Discard</strong> them? Click <strong>Cancel</strong> to continue editing.',
 			'Save edits?',
-			'alert',
-			footerButtons,
-			{eventHandlerCallable: eventHandler}
+			{
+				footerButtons: footerButtons,
+				eventHandlerCallable: eventHandler
+			}
 		)
 	}
 
@@ -216,7 +217,7 @@ class ClimberDBConfig extends ClimberDB {
 		const $cuaInputs = $('.cua-table-input.dirty');
 
 		if (![...$configInputs, ...$cuaInputs].length) {
-			showModal('You have not yet made any edits to save.', 'No edits to save');
+			this.showModal('You have not yet made any edits to save.', 'No edits to save');
 			return;
 		}
 
@@ -244,7 +245,7 @@ class ClimberDBConfig extends ClimberDB {
 			const inputValue = $el.val();
 			if (inputValue == 'None') {
 				hideLoadingIndicator();
-				showModal(
+				this.showModal(
 					'The CUA company code option for "None" is always included by default.' +
 					' Delete this row to save any other edits or additions.', 
 					'Invalid CUA Company Name'
@@ -300,7 +301,7 @@ class ClimberDBConfig extends ClimberDB {
 				this.toggleBeforeUnload(false);
 			}
 		}).fail((xhr, status, error) => {
-			showModal(`An unexpected error occurred while saving data to the database: ${error}.${this.getDBContactMessage()}`, 'Unexpected error');
+			this.showModal(`An unexpected error occurred while saving data to the database: ${error}.${this.getDBContactMessage()}`, 'Unexpected error');
 			// roll back in-memory data
 		}).always(() => {
 		 	this.hideLoadingIndicator();
@@ -422,7 +423,7 @@ class ClimberDBConfig extends ClimberDB {
 					})
 				})
 			}
-			showModal(message, 'Remove CUA Guide Company', 'alert', footerButtons, {eventHandlerCallable: eventHandler});
+			this.showModal(message, 'Remove CUA Guide Company', {footerButtons: footerButtons, eventHandlerCallable: eventHandler});
 		}
 	}
 

--- a/web/js/dashboard.js
+++ b/web/js/dashboard.js
@@ -311,10 +311,7 @@ class ClimberDBDashboard extends ClimberDB {
 			sql: bcSQL, 
 			sqlParameters: {status_codes: [statusCodes.onMountain, statusCodes.offMountain]} 
 		}).done(response => {
-			if (this.pythonReturnedError(response)) {
-				showModal('There was an error while query backcountry stats to date.', 'Database Error')
-				return;
-			} else {
+			if (!this.pythonReturnedError(response, {errorExplanation: 'There was an error while query backcountry stats to date.'})) {
 				const result = response.data || []
 				$('#season-mountain-stats-card .bc-stats-table tbody').append(`
 					<tr>
@@ -467,14 +464,7 @@ class ClimberDBDashboard extends ClimberDB {
 		`;
 		return this.queryDB({sql: sql, sqlParameters: {start_date: `${year}-1-1`}})
 			.done((response) => {
-				if (this.pythonReturnedError(response)) {
-					showModal(
-						`An error occurred while querying group status. Make sure you're` + 
-						` connected to the NPS network and reload the page. If the` + 
-						` problem persists, contact your IT administrator.`, 
-						'Database error'
-					);
-				} else {
+				if (!this.pythonReturnedError(response, {errorExplanation: 'An error occurred while querying group status.'})) {
 					const dropdowns = {};
 					const nExpeditions = {};
 					for (const row of response.data) {
@@ -562,13 +552,7 @@ class ClimberDBDashboard extends ClimberDB {
 
 		return this.queryDB({sql: sql})
 			.done(response => {
-	        	if (this.pythonReturnedError(response)) {
-	        		showModal(
-	        			`An error occurred while querying breifings. Make sure you're` + 
-	        			` connected to the NPS network and reload the page. If the` + 
-	        			` problem persists, contact your IT administrator.`, 
-	        			'Database error'
-	        		);
+	        	if (this.pythonReturnedError(response, {errorExplanation: 'An error occurred while querying breifings.'})) {
 	        		return false; // Save was unsuccessful
 	        	} else {
 	        		let queryResult = response.data || [];
@@ -699,9 +683,7 @@ class ClimberDBDashboard extends ClimberDB {
 			this.configureMap('bc-groups-map', {mapObject: this.maps.main, showBackcountryUnits: false}),
 			queryDeferred
 		).done((_, [queryResponse]) => { // ignore .configureMap() response
-			if (this.pythonReturnedError(queryResponse)) {
-				showModal('Backcountry groups could not be queried because there was an unexpected error: <br><br>' + queryResponse, 'Unexpected Error')
-			} else {
+			if (!this.pythonReturnedError(queryResponse, {errorExplanation: 'Backcountry groups could not be queried because there was an unexpected error.'})) {
 				const icon = L.icon({
 					iconUrl: '../imgs/camp_icon_50px.png',
 					iconSize: [35, 35],

--- a/web/js/dashboard.js
+++ b/web/js/dashboard.js
@@ -711,7 +711,7 @@ class ClimberDBDashboard extends ClimberDB {
 					.text(result.length);
 			}
 		}).fail(() => {
-			showModal('There was a problem loading backcountry group data', 'Database Error')
+			this.showModal('There was a problem loading backcountry group data', 'Database Error')
 		})
 	}
 

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -393,7 +393,7 @@ class ClimberDBExpeditions extends ClimberDB {
 						+ ` climber is actually a commercial guide, <a href="climbers.html?id=${climberID}`
 						+ `&edit=true" target="_blank">edit their climber profile</a>. You can then reload`
 						+ ` this page and mark them as a guide on this expedition.`;
-					showModal(message, 'Climber Is Not A Guide');
+					this.showModal(message, 'Climber Is Not A Guide');
 					$checkbox.prop('checked', false).change();
 				}
 			}
@@ -515,12 +515,11 @@ class ClimberDBExpeditions extends ClimberDB {
 				const memberName = first_name + ' ' + last_name;
 				const $routeInput = $li.closest('.card').find('.route-code-header-input:not(.mountain-code-header-input)');
 				const routeName = $routeInput.find(`option[value=${$routeInput.val()}]`).text();//this.routeCodes[$li.find('.input-field[name="route_code"]').val()].name;
-				showModal(
+				this.showModal(
 					`Are you sure you want to remove <strong>${memberName}</strong> from the <strong>${routeName}</strong> route?`, 
 					'Remove expedition member from this route?', 
-					'alert', 
-					footerButtons,
 					{
+						footerButtons: footerButtons,
 						eventHandlerCallable: onConfirmClickHandler
 					}
 				);
@@ -595,7 +594,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		$('.add-comms-button').click(e => {
 			
 			if (!$('#expedition-members-accordion .card:not(.cloneable)').length) {
-				showModal('You must add at least one expedition member before you can add a communcation device.', 'Invalid Action');
+				this.showModal('You must add at least one expedition member before you can add a communcation device.', 'Invalid Action');
 				return;
 			}
 
@@ -746,7 +745,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			const currentYear = new Date().getFullYear();
 			if (departureYear < currentYear) {
 				const formattedDeparture = departureDate.toLocaleDateString('en-US', {month: 'long', day: 'numeric', year: 'numeric'});
-				showModal(
+				this.showModal(
 					`This expedition was scheduled to depart on <strong>${formattedDeparture}</strong>.` + 
 					' Make sure this is the group you intended to edit.', 
 					'WARNING: Editing Legacy Data'
@@ -1108,7 +1107,7 @@ class ClimberDBExpeditions extends ClimberDB {
 							}).fail((xhr, status, error) => {
 								const message = 'And error occurred while attempting to delete this route:' + 
 								 ` ${error}.${this.getDBContactMessage()}`;
-								showModal(message, 'Database Error');
+								this.showModal(message, 'Database Error');
 							})
 					})
 				}
@@ -1121,7 +1120,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">Cancel</button>
 				<button class="generic-button modal-button danger-button close-modal confirm-button" data-dismiss="modal">OK</button>
 			`;
-			showModal(message, `Delete ${displayName}?`, 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
+			this.showModal(message, `Delete ${displayName}?`, {footerButtons: footerButtons, eventHandlerCallable: onConfirmClickHandler});
 		}
 	}
 
@@ -1186,12 +1185,14 @@ class ClimberDBExpeditions extends ClimberDB {
 				<button class="generic-button modal-button primary-button close-modal add-selected-button" data-dismiss="modal">Add selected</button>
 				<button class="generic-button modal-button primary-button close-modal add-all-button" data-dismiss="modal">Add All</button>
 			`;
-			showModal(
+			this.showModal(
 				message, 
 				'Select expedition member(s) to add', 
-				'confirm', 
-				footerButtons,
-				{eventHandlerCallable: onClickHandler});
+				{ 
+					footerButtons: footerButtons,
+					eventHandlerCallable: onClickHandler
+				}
+			);
 		}
 	} 
 
@@ -1206,7 +1207,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		const $routeInput = $button.closest('.card').find('.route-code-header-input:not(.mountain-code-header-input)');
 		const routeCode = $routeInput.val();
 		if (routeCode === '') {
-			showModal('You must select a mountain and route first before you can mark that all climbers summited.', 'No Route Selected');
+			this.showModal('You must select a mountain and route first before you can mark that all climbers summited.', 'No Route Selected');
 			return;
 		}
 		const routeName = $routeInput.find(`option[value=${routeCode}]`).text();
@@ -1261,7 +1262,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">Cancel</button>
 			<button class="generic-button modal-button danger-button close-modal confirm-button" data-dismiss="modal">OK</button>
 		`;
-		showModal(message, title, 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
+		this.showModal(message, title, {footerButtons: footerButtons, eventHandlerCallable: onConfirmClickHandler});
 	}
 
 
@@ -1319,7 +1320,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			.has('.input-field.dirty, .input-field:required:invalid');
 		
 		if (!$editParents.length) {
-			showModal('You have not made any edits to save yet.', 'No edits to save');
+			this.showModal('You have not made any edits to save yet.', 'No edits to save');
 			hideLoadingIndicator();
 			return;
 		}
@@ -1340,7 +1341,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			.join('');
 
 			setTimeout(
-				() => {showModal(`The following fields are not filled. All required fields must be filled before you can save your edits:<ul>${errorFieldList}</ul>`, 'Required Field Is Empty')},
+				() => {this.showModal(`The following fields are not filled. All required fields must be filled before you can save your edits:<ul>${errorFieldList}</ul>`, 'Required Field Is Empty')},
 				500
 			);
 			hideLoadingIndicator();
@@ -1650,7 +1651,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				return this.queryExpedition(expeditionID, {showOnLoadWarnings: false}) //suppress flagged expedition member warnings
 			}
 		}).fail((xhr, status, error) => {
-			showModal(`An unexpected error occurred while saving data to the database: ${error}.${this.getDBContactMessage()}`, 'Unexpected error');
+			this.showModal(`An unexpected error occurred while saving data to the database: ${error}.${this.getDBContactMessage()}`, 'Unexpected error');
 		}).always(() => {
 			 	this.hideLoadingIndicator();
 			});
@@ -1759,12 +1760,13 @@ class ClimberDBExpeditions extends ClimberDB {
 			<button class="generic-button modal-button primary-button confirm-button close-modal" data-dismiss="modal">Save</button>
 		`;
 
-		showModal(
+		this.showModal(
 			`You have unsaved edits to this expedition. Would you like to <strong>Save</strong> or <strong>Discard</strong> them? Click <strong>Cancel</strong> to continue editing this expedition.`,
 			'Save edits?',
-			'alert',
-			footerButtons,
-			{eventHandlerCallable: onClickHandler}
+			{
+				footerButtons: footerButtons,
+				eventHandlerCallable: onClickHandler
+			}
 		);
 	}
 
@@ -1794,7 +1796,7 @@ class ClimberDBExpeditions extends ClimberDB {
 					}
 				})
 				.fail((xhr, status, error) => {
-					showModal(`An unexpected error occurred while deleting data from the database: ${error}.`, 'Unexpected error');
+					this.showModal(`An unexpected error occurred while deleting data from the database: ${error}.`, 'Unexpected error');
 				})
 				.always(() => {
 					hideLoadingIndicator();
@@ -1847,7 +1849,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				' edits will be removed.';
 		}
 		
-		showModal(message, title, 'alert', footerButtons, {eventHandlerCallable: eventHandler});
+		this.showModal(message, title, {footerButtons: footerButtons, eventHandlerCallable: eventHandler});
 	} 
 
 
@@ -1856,7 +1858,7 @@ class ClimberDBExpeditions extends ClimberDB {
 	*/
 	showChangeExpeditionModal($card) {
 		if ($card.is('.new-card')) {
-			showModal('You can\'t move this expedition member to a different expedition until you have saved their information. Either save their information first or delete this expedition member and enter add them to the correct expedition.', 'Invalid Operation');
+			this.showModal('You can\'t move this expedition member to a different expedition until you have saved their information. Either save their information first or delete this expedition member and enter add them to the correct expedition.', 'Invalid Operation');
 			return;
 		}
 		// default to -1 because ID will never equal -1, although a fallback option shouldn't 
@@ -1916,7 +1918,7 @@ class ClimberDBExpeditions extends ClimberDB {
 					$('#input-expedition_name').addClass('ignore-duplicates');
 				});
 			}
-			showModal(message, 'Duplicate Expedition Name', 'alert', footerButtons, {eventHandlerCallable: eventHandler});
+			this.showModal(message, 'Duplicate Expedition Name', {footerButtons: footerButtons, eventHandlerCallable: eventHandler});
 		}
 	}
 
@@ -1965,7 +1967,7 @@ class ClimberDBExpeditions extends ClimberDB {
 						.change(); 
 				})
 			}
-			//showModal(message, 'Update Planned Departure?', 'confirm', '', {eventHandlerCallable: eventHandlerCallable});
+			//this.showModal(message, 'Update Planned Departure?', {modalType: 'confirm', eventHandlerCallable: eventHandlerCallable});
 		}
 	}
 
@@ -2003,7 +2005,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			const eventHandlerCallable = () => {
 				$('#alert-modal button').click(() => {this.revertInputValue($select)})
 			}
-			showModal(message, 'Missing Payment/Information', 'alert', '', {eventHandlerCallable: eventHandlerCallable})
+			this.showModal(message, 'Missing Payment/Information', {eventHandlerCallable: eventHandlerCallable})
 			return false;
 		} else {
 			return true;
@@ -2112,7 +2114,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			const expeditionInfo =  this.expeditionInfo;
 			
 			if ($memberCards.length === 0) {
-				showModal(`You have not added any (non-canceled) expedition members yet, so this expedition's status can't be changed to <strong>${status}</strong>.`, 'No Expedition Members');
+				this.showModal(`You have not added any (non-canceled) expedition members yet, so this expedition's status can't be changed to <strong>${status}</strong>.`, 'No Expedition Members');
 				this.revertInputValue($select, {triggerChange: true})
 				return;
 			} else if ($memberCards.length === 1) {
@@ -2190,7 +2192,7 @@ class ClimberDBExpeditions extends ClimberDB {
 							})
 					})
 				}
-				showModal(message, 'Cancel Briefing?', 'confirm', footerButtons, {eventHandlerCallable: eventHandler})
+				this.showModal(message, 'Cancel Briefing?', {footerButtons: footerButtons, eventHandlerCallable: eventHandler})
 			}
 		}
 	}
@@ -2254,7 +2256,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				const result = response.data || [];
 				if (result.length) {
 					const climberName = $('#modal-expedition-search-bar-label > span').text();
-					showModal(`${climberName} is already a member of ${selectedExpeditionName}. If you think this is an error, check which expedition member record has the most complete or up-to-date information and delete the other one. Then change their expedition if necessary.`, 'Duplicate Expedition Member');
+					this.showModal(`${climberName} is already a member of ${selectedExpeditionName}. If you think this is an error, check which expedition member record has the most complete or up-to-date information and delete the other one. Then change their expedition if necessary.`, 'Duplicate Expedition Member');
 				} else {
 					const $searchBar = $('#modal-expedition-search-bar');
 					
@@ -2281,7 +2283,7 @@ class ClimberDBExpeditions extends ClimberDB {
 					if (result.length) {
 						const departureYear = new Date(result[0].planned_departure_date).getFullYear();
 						if (departureYear < new Date().getFullYear()) {
-							showModal(`You selected the expedition <strong>${selectedExpeditionName}</strong> which has a planned departure from <strong>${departureYear}</strong>. Make sure you selected the right expedition before confirming the expedition change.`, 'Selected Expedition From Previous Year')
+							this.showModal(`You selected the expedition <strong>${selectedExpeditionName}</strong> which has a planned departure from <strong>${departureYear}</strong>. Make sure you selected the right expedition before confirming the expedition change.`, 'Selected Expedition From Previous Year')
 						}
 					}
 				}
@@ -2354,12 +2356,13 @@ class ClimberDBExpeditions extends ClimberDB {
 					$listItem.find('.file-input-label').click();
 				})
 			}
-			showModal(
+			this.showModal(
 				message, 
 				`Add ${attachmentTypeName}?`, 
-				'confirm', 
-				footerButtons, 
-				{eventHandlerCallable: onConfirmClick}
+				{ 
+					footerButtons: footerButtons, 
+					eventHandlerCallable: onConfirmClick
+				}
 			)
 		}
 	}
@@ -2401,7 +2404,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			}).fail((xhr, status, error) => {
 				const message = 'The expedition member could not be moved to a new expedition because' +
 					` of an unexpected error: ${error}.${this.getDBContactMessage()}`;
-				showModal(message, 'Database Error');
+				this.showModal(message, 'Database Error');
 			}).always(() => {
 				hideLoadingIndicator();
 			});
@@ -2468,14 +2471,14 @@ class ClimberDBExpeditions extends ClimberDB {
 		const nRoutes = $('#routes-accordion .card:not(.cloneable)').length;
 		const groupStatus = $('#input-group_status').val();
 		if (nMembers === 0) {
-			showModal(
+			this.showModal(
 				'There are no active members of this expedition. You must add at least one member or' +
 				' set at least one member\'s status to something other than "cancelled".', 
 				'No Expedition Members'
 			);
 			return;
 		} else if ((exportType === 'confirmation_letter') && !$('.input-field[name=is_trip_leader]:checked').length) {
-			showModal(
+			this.showModal(
 				'No expedition member has been designated as the trip leader yet. You must' +
 					' specify a trip leader before you can export this expedition\'s confirmation letter.' +
 					' To specify the leader for the expedition, hover over the member you want to' + 
@@ -2484,13 +2487,13 @@ class ClimberDBExpeditions extends ClimberDB {
 			);
 			return;
 		} else if ((exportType === 'registration_card') && (nRoutes === 0)) {
-			showModal('You must add at least one route before you can export the expedition\'s registration card', 'No Routes Entered');
+			this.showModal('You must add at least one route before you can export the expedition\'s registration card', 'No Routes Entered');
 			return;
 		} else if (exportType === 'special_use_permit') {
 			if (this.constants.groupStatusCodes.confirmed <= groupStatus && groupStatus <= this.constants.groupStatusCodes.offMountain) {
 				this.showExportPermitModal();
 			} else {
-				showModal(
+				this.showModal(
 					'At least one (non-canceled) expedition member has not yet been confirmed. The' + 
 						' expedition must have a group status of "Confirmed", "On Mountain", or "Off' +
 						' Mountain" to export Special User Permits.',
@@ -2698,7 +2701,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		
 		// warn user and exit if no checkboxes are selected
 		if (expeditionMemberIDs.length === 0) {
-			showModal('You must select at least one expedition member to export a Special Use Permit for.', 'Invalid Operation');
+			this.showModal('You must select at least one expedition member to export a Special Use Permit for.', 'Invalid Operation');
 			return;
 		}	
 
@@ -2733,7 +2736,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		}).fail((xhr, status, error) => {
 			const message = 'The Special User Permit(s) could not be exported because' +
 				` of an unexpected error: ${error}.${this.getDBContactMessage()}`;
-			showModal(message, 'Unexpected Error');
+			this.showModal(message, 'Unexpected Error');
 		}).always(() => {hideLoadingIndicator()})
 	}
 
@@ -2753,13 +2756,13 @@ class ClimberDBExpeditions extends ClimberDB {
 				this.constants.groupStatusCodes.offMountain
 			];
 		if (!allowableGroupStatuses.includes(groupStatusCode)) {
-			showModal(`The group status for this expedition is not 'Confirmed', 'On Mountain', or 'Off Mountain', so cache tags can't be printed.`, 'Invalid Group Status');
+			this.showModal(`The group status for this expedition is not 'Confirmed', 'On Mountain', or 'Off Mountain', so cache tags can't be printed.`, 'Invalid Group Status');
 			return;
 		}
 
 		// If there are unsaved edits, prompt the user to either save or discard them
 		if ($('.dirty').length) {
-			showModal(`You have unsaved edits. Either click the <strong>Save</strong> button to keep your edits or click the <strong>Edit</strong> button and choose <strong>Discard</strong> to undo your edits. Then you can print cache tags.`, 'Unsaved Edits')
+			this.showModal(`You have unsaved edits. Either click the <strong>Save</strong> button to keep your edits or click the <strong>Edit</strong> button and choose <strong>Discard</strong> to undo your edits. Then you can print cache tags.`, 'Unsaved Edits')
 			return;
 		} 
 		// Or if not, show the user a preview of the image
@@ -2767,7 +2770,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			// get cache tag data
 			let tripLeaderInfo = Object.values(this.expeditionInfo.expedition_members.data).filter(info => info.is_trip_leader === true)
 			if (!tripLeaderInfo.length) {
-				showModal('You have not selected a trip leader yet. You select a trip leader before you can create cache tags', 'No Trip Leader Specified');
+				this.showModal('You have not selected a trip leader yet. You select a trip leader before you can create cache tags', 'No Trip Leader Specified');
 				return;
 			} else {
 				tripLeaderInfo = tripLeaderInfo[0];
@@ -2801,7 +2804,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			}).fail((xhr, status, error) => {
 				const message = 'An error occurred while generating the cache tag preview: ' + 
 					`${error}.${this.getDBContactMessage()}`; 
-				showModal(message, 'Unexpected Error')
+				this.showModal(message, 'Unexpected Error')
 			}).always(() => {hideLoadingIndicator()});
 		}
 	}
@@ -2814,13 +2817,13 @@ class ClimberDBExpeditions extends ClimberDB {
 		// Check that the number of labels to print is filled in
 		const nLabels = $('#input-label_print_quantity').val();
 		if (!nLabels) {
-			showModal('You must enter a number of cache tag labels to print', 'Enter Print Quantity');
+			this.showModal('You must enter a number of cache tag labels to print', 'Enter Print Quantity');
 			return;
 		}
 
 		const zpl = $(e.target).data('zpl');
 		if (!zpl.length) {
-			showModal('An unexpected error occurred and the label data could not be sent to the printer. Try closing and reopening the <strong>Cache Tag Print Preview</strong> dialog', 'Unexpected Printing Error')
+			this.showModal('An unexpected error occurred and the label data could not be sent to the printer. Try closing and reopening the <strong>Cache Tag Print Preview</strong> dialog', 'Unexpected Printing Error')
 		}
 		showLoadingIndicator('onPrintCacheTagButtonClick');
 
@@ -2835,7 +2838,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				// dismiss the print preview modal
 				$('#cache-tag-modal').modal('hide');
 				
-				showModal(
+				this.showModal(
 					nLabels > 1 ? `All ${nLabels} cache tags printed successfully.` : 'Your cache tag printed successfully', 
 					'Check Your Printer!'
 				);
@@ -2843,7 +2846,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		}).fail((xhr, status, error) => {
 			const message = 'An unexpected error occurred while printing cache tags:' +
 				` ${error}.${this.getDBContactMessage()}`	
-			showModal(message, 'Unexpected Error');
+			this.showModal(message, 'Unexpected Error');
 		}).always(() => {hideLoadingIndicator()})
 	}
 
@@ -2905,7 +2908,7 @@ class ClimberDBExpeditions extends ClimberDB {
 					const message = `An expedition member has already been added within`
 						+ ` ${climberAdditionDayRestriction} days of this group's planned departure of ` 
 						+ departureDateString.toLocaleDateString('en-US', {month: 'long', day: 'numeric', timezone: 'UTC'});
-					showModal(message, 'WARNING: 30-Day Rule Violation');
+					this.showModal(message, 'WARNING: 30-Day Rule Violation');
 					break;
 				}
 			}
@@ -2917,7 +2920,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		let maxClimbers = this.config.max_expedition_members
 		if ($('#input-guide_company')) maxClimbers ++;
 		if (nMembers >= maxClimbers) {
-			showModal(
+			this.showModal(
 				`This group has reached or exceeded the maximum group size of ${maxClimbers} with ${nMembers} expedition members`,
 				'WARNING: Group Size Violation'
 			)
@@ -2935,11 +2938,10 @@ class ClimberDBExpeditions extends ClimberDB {
 			daysToDeparture <= previousClimberAdditionDays;
 		
 		if (limitToPreviousClimbers)	{
-			showModal('This expedition is scheduled to depart in ' + previousClimberAdditionDays + ' days or less. Only climbers who have previously climbed Denali or Foraker can be added to this expedition. When you search for climbers, the results will automatically be limited to only climbers who meet this criteria.', 
+			this.showModal('This expedition is scheduled to depart in ' + previousClimberAdditionDays + ' days or less. Only climbers who have previously climbed Denali or Foraker can be added to this expedition. When you search for climbers, the results will automatically be limited to only climbers who meet this criteria.', 
 				'WARNING: 7-Day Rule in Effect',
-				'alert',
-				'',
 				{
+					modalType: 'alert',
 					eventHandlerCallable: () => {
 						$('.confirm-button').click(() => {$('#modal-climber-search-bar').focus()})
 					}
@@ -3084,7 +3086,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		const climberID = $('#modal-climber-select').val();
 		const climberInfo = this.climberForm.selectedClimberInfo.climbers[climberID];
 		if (currentClimberIDs.includes(climberID)) {
-			showModal(`${climberInfo.first_name} ${climberInfo.last_name} is already a member of the expedition '${this.expeditionInfo.expeditions.expedition_name}'`, 'Climber is already a member');
+			this.showModal(`${climberInfo.first_name} ${climberInfo.last_name} is already a member of the expedition '${this.expeditionInfo.expeditions.expedition_name}'`, 'Climber is already a member');
 			return;
 		}
 
@@ -3131,7 +3133,7 @@ class ClimberDBExpeditions extends ClimberDB {
 						.change();
 				})
 			}
-			showModal(message, 'Is This Climber Guiding?', 'confirm', footerButtons, {eventHandlerCallable: eventHandler});
+			this.showModal(message, 'Is This Climber Guiding?', {footerButtons: footerButtons, eventHandlerCallable: eventHandler});
 		}
 		
 		$(e.target).siblings('.close-modal-button').click();
@@ -3784,11 +3786,11 @@ class ClimberDBExpeditions extends ClimberDB {
 					const isBackcountry = expeditionResult[0].is_backcountry;
 					if (pageName.match('expedition') && isBackcountry) {
 						const message = `You're trying to view a Backcountry group on the Expedition page. View this group on <a href="backcountry.html?id=${expeditionID}">the Backcountry page</a> instead.`;
-						showModal(message, 'Invalid Expedition');
+						this.showModal(message, 'Invalid Expedition');
 						return;
 					} else if (pageName.match('backcountry') && !isBackcountry) {
 						const message = `You're trying to view a Denali or Foraker expedition on the Backcountry page. View this group on <a href="expeditions.html?id=${expeditionID}">the Expeditons page</a> instead.`;
-						showModal(message, 'Invalid Backcountry Group');
+						this.showModal(message, 'Invalid Backcountry Group');
 						return;
 					}
 
@@ -3800,7 +3802,7 @@ class ClimberDBExpeditions extends ClimberDB {
 					this.expeditionInfo.expeditions.id = firstRow.expedition_id;
 				} else {
 					const footerButton = '<button class="generic-button modal-button close-modal" onclick="climberDB.createNewExpedition()" data-dismiss="modal">Close</button>';
-					showModal(`There are no expeditions with the database ID '${expeditionID}'. This expedition was either deleted or the URL you are trying to use is invalid.`, 'Invalid Expedition ID', 'alert', footerButton);
+					this.showModal(`There are no expeditions with the database ID '${expeditionID}'. This expedition was either deleted or the URL you are trying to use is invalid.`, 'Invalid Expedition ID', 'alert', footerButton);
 				}
 
 				// Get data for right-side tables
@@ -3953,7 +3955,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			const message = 
 				'An unexpected error occurred while querying this expedition:' + 
 				` ${error}.${this.getDBContactMessage()}`;
-			showModal(message, 'Database Error');
+			this.showModal(message, 'Database Error');
 		}).always(() => {hideLoadingIndicator()});
 	}
 
@@ -3988,7 +3990,7 @@ class ClimberDBExpeditions extends ClimberDB {
 					}
 				}, 
 				(xhr, status, error) => {
-					showModal(`An unexpected error occurred while deleting data from the database: ${error}.${this.getDBContactMessage()}`, 'Unexpected error');
+					this.showModal(`An unexpected error occurred while deleting data from the database: ${error}.${this.getDBContactMessage()}`, 'Unexpected error');
 				}
 			);
 	}
@@ -4016,12 +4018,13 @@ class ClimberDBExpeditions extends ClimberDB {
 				<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">No</button>
 				<button class="generic-button modal-button danger-button close-modal" data-dismiss="modal">OK</button>
 			`;
-			showModal(
+			this.showModal(
 				`Are you sure you want to delete this checkout record for CMC ${cmcID}?`, 
 				'Delete CMC?', 
-				'alert', 
-				footerButtons,
-				{eventHandlerCallable: onConfirmClickHandler}
+				{
+					footerButtons: footerButtons,
+					eventHandlerCallable: onConfirmClickHandler
+				}
 			);
 		}
 
@@ -4054,12 +4057,13 @@ class ClimberDBExpeditions extends ClimberDB {
 				<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">No</button>
 				<button class="generic-button modal-button danger-button close-modal" data-dismiss="modal">OK</button>
 			`;
-			showModal(
+			this.showModal(
 				`Are you sure you want to delete this ${deviceType} from ${expeditionName}'s communication device list?`, 
 				'Delete Comms Device?', 
-				'alert', 
-				footerButtons,
-				{eventHandlerCallable: onConfirmClickHandler}
+				{ 
+					footerButtons: footerButtons,
+					eventHandlerCallable: onConfirmClickHandler
+				}
 			);
 		}
 	}
@@ -4150,7 +4154,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		// Prevent the user from creating a refund post manually because 
 		//	a refund post should be managed automatically
 		if (transactionTypeCode === 27 || transactionTypeCode === 28) {
-			showModal('You can\'t add a refund post directly to the transaction history. If you want to add a refund, just add a "Climbing fee refund" or "Entrance fee refund" and the refund post will be added automatically.', 'Invalid Operation')
+			this.showModal('You can\'t add a refund post directly to the transaction history. If you want to add a refund, just add a "Climbing fee refund" or "Entrance fee refund" and the refund post will be added automatically.', 'Invalid Operation')
 			$select.val(previousTransactionType);
 			return;
 		}
@@ -4263,7 +4267,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">Cancel</button>
 				<button class="generic-button modal-button danger-button confirm-button close-modal" data-dismiss="modal">OK</button>
 			`
-			showModal(message, 'Permanently Delete Transaction?', 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
+			this.showModal(message, 'Permanently Delete Transaction?', {footerButtons: footerButtons, eventHandlerCallable: onConfirmClickHandler});
 		}
 	}
 
@@ -4291,7 +4295,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		//	the new attachment record to an expedition_member record. In this case, saving the attachment 
 		//	file and db record can be handled completely server-side 
 		if ($button.closest('.card').is('.new-card')) {
-			showModal('You must save this expedition member before you can add an attachment.', 'Invalid Operation');
+			this.showModal('You must save this expedition member before you can add an attachment.', 'Invalid Operation');
 			return;
 		}
 		this.addAttachmentListItem($button.closest('.attachments-tab-pane').find('.data-list'));
@@ -4325,6 +4329,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				entryForm.updateAttachmentAcceptString('${fileTypeSelectID}');
 				$('#${fileInputID}').click();
 			`;
+			// **** move to eventHandler ****
 			const footerButtons = `
 				<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal" onclick="$('#${fileTypeSelectID}').val('${previousFileType}');">No</button>
 				<button class="generic-button modal-button danger-button close-modal" data-dismiss="modal" onclick="${onConfirmClick}">Yes</button>
@@ -4334,7 +4339,8 @@ class ClimberDBExpeditions extends ClimberDB {
 				.filter((_, option) => {return option.value === fileTypeCode})
 				.html()
 				.toLowerCase();
-			showModal(`You already selected a file. Do you want to upload a new <strong>${fileType}</strong> file instead?`, `Upload a new file?`, 'confirm', footerButtons);
+
+			this.showModal(`You already selected a file. Do you want to upload a new <strong>${fileType}</strong> file instead?`, `Upload a new file?`, {footerButtons: footerButtons});
 		} else {
 			_this.updateAttachmentAcceptString($fileTypeSelect.attr('id'));
 		}
@@ -4366,7 +4372,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			reader.onerror = function(e) {
 				// Hide preview and progress bar and notify the user
 				$progressBar.ariaHide();
-				showModal(`The file '${filename}' failed to upload correctly.${this.getDBContactMessage()}`, 'Upload failed');
+				this.showModal(`The file '${filename}' failed to upload correctly.${this.getDBContactMessage()}`, 'Upload failed');
 			}
 
 			// Get local reference to .attachments attribute because `this` refers to the FieReader 
@@ -4433,7 +4439,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			.filter(v => v) // drop null values
 		const filename = el.files[0].name;
 		if (existingfilenames.includes(filename)) {
-			showModal(`An attachment with the filename <strong>${filename}</strong> already` + 
+			this.showModal(`An attachment with the filename <strong>${filename}</strong> already` + 
 				' exists. All attachments for an expedition must have unique filenames.' + 
 				' Please rename the file and upload it again.', 'Duplicate filename')
 			return;
@@ -4548,14 +4554,15 @@ class ClimberDBExpeditions extends ClimberDB {
 			const footerButtons = 
 				'<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">Cancel</button>' +
 				'<button class="generic-button modal-button danger-button close-modal confirm-delete" data-dismiss="modal">Delete</button>';
-			showModal(message, title, 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});	
+				// TEST ****
+			this.showModal(message, title, {footerButtons: footerButtons, eventHandlerCallable: onConfirmClickHandler});	
 		}
 	}
 
 
 	onAddRouteButtonClick(e) {
 		if (!$('#expedition-members-accordion .card:not(.cloneable)').length) {
-			showModal('You must add at least one expedition member before you can add a route.', 'Invalid Action');
+			this.showModal('You must add at least one expedition member before you can add a route.', 'Invalid Action');
 			return;
 		}
 
@@ -4630,7 +4637,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				` which is greater than the summit elevation of <strong>${summitElevation}</strong>. If the elevation you entered` + 
 				` is correct, you will have to manually check the <em>Summited?</em> checkbox. Otherwise,` +
 				` correct the <em>Highest elevation</em>`;
-			showModal(message, 'Invalid Highest Elevation')
+			this.showModal(message, 'Invalid Highest Elevation')
 			return;
 		}
 
@@ -4748,7 +4755,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			const message = `${nFlagged} ${nFlagged === 1 ? ' member of this expedition has' : ' members of this expedition have'}` +
 				' been flagged. You might want to review the reason they were flagged. Flagged expedition member(s):\n' +
 				`<ul>${flaggedMemberListItems}</ul>`
-			return showModal(message, 'Flagged Epedition Member(s)');
+			return this.showModal(message, 'Flagged Epedition Member(s)');
 		}
 	}
 
@@ -4783,7 +4790,7 @@ class ClimberDBExpeditions extends ClimberDB {
 			if (supsNotComplete) 	 reasons += `<li>${nSUPsNotComplete} climber${nSUPsNotComplete > 1 ? 's have' : ' has'} not submitted their SUP application</li>`;
 			if (psarNotComplete)	 reasons += `<li>${nPSARNotComplete} climber${nPSARNotComplete > 1 ? 's have' : ' has'} not submitted their PSAR form</li>`;
 			const message = `This expedition is 60 days or less from their scheduled departure date on <strong>${departureDate.toLocaleDateString('en-US', {month: 'long', day: 'numeric'})}</strong>, but not all expedition members have completed the requirements to receive a permit. These unfulfilled requirements include: <ul>${reasons}</ul>You should verify that these requirements have not been fulfilled, and if not, change the groups departure date to on or after <strong>${newDepartureDate}</strong>.`;
-			showModal(message, 'WARNING: 60-Day Rule Violation');
+			this.showModal(message, 'WARNING: 60-Day Rule Violation');
 		}
 	}
 

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -111,17 +111,14 @@ class ClimberDBIndex extends ClimberDB {
 			},
 			cache: false
 		}).done(resultString => {
-			const pythonError = this.pythonReturnedError(resultString);
-			if (pythonError !== false) {
-				showModal(`Password reset email failed to send with the error:\n${pythonError.trim()}. Make sure you're still connected to the NPS network and try again. Contact your <a href="mailto:${this.config.db_admin_email}">database adminstrator</a> if the problem persists.`, 'Email Server Error')
-			} else {
+			if (!this.pythonReturnedError(resultString, {errorExplanation: 'The password reset email failed to send because of an unexpected error.'})) {
 				// show success message
 				$('#sign-in-form-container > *:not(.email-success-message-container)').ariaHide();
 				$('.email-success-message-container').ariaHide(false)
 				$('#reset-password-success-message').ariaHide(false);
 			}
 		}).fail((xhr, status, error) => { 
-			showModal(`Password reset email failed to send with the error: ${error}. Make sure you're still connected to the NPS network and try again. Contact your <a href="mailto:${this.config.db_admin_email}">database adminstrator</a> if the problem persists.`, 'Email Server Error')
+			showModal(`Password reset email failed to send with the error: ${error}.${this.getDBContactMessage()}`, 'Email Server Error')
 		}).always(() => {this.toggleDotLoadingIndicator($buttonContainer, {hide: true})})
 	}
 

--- a/web/js/index.js
+++ b/web/js/index.js
@@ -65,7 +65,7 @@ class ClimberDBIndex extends ClimberDB {
 		this.verifyPassword(password)
 			.done(isValid => {
 				if (!isValid) {
-					//showModal('Password incorrect', 'Incorrect password');
+					//this.showModal('Password incorrect', 'Incorrect password');
 					this.showInvalidPasswordMessage('#incorrect-password-message');
 				} else {
 					const stayLoggedIn = $('#retain-login-checkbox').prop('checked');
@@ -118,7 +118,7 @@ class ClimberDBIndex extends ClimberDB {
 				$('#reset-password-success-message').ariaHide(false);
 			}
 		}).fail((xhr, status, error) => { 
-			showModal(`Password reset email failed to send with the error: ${error}.${this.getDBContactMessage()}`, 'Email Server Error')
+			this.showModal(`Password reset email failed to send with the error: ${error}.${this.getDBContactMessage()}`, 'Email Server Error')
 		}).always(() => {this.toggleDotLoadingIndicator($buttonContainer, {hide: true})})
 	}
 
@@ -160,10 +160,10 @@ class ClimberDBIndex extends ClimberDB {
 				$('#sign-in-form-container').ariaHide();
 				$('#account-request-success-message').ariaHide(false);
 			} else {
-				showModal('There was a problem submitting your request. Check your network connection and try again.', 'Unexpected error');
+				this.showModal('There was a problem submitting your request. Check your network connection and try again.', 'Unexpected error');
 			}
 		}).fail((xhr, status, error) => {
-			showModal(`There was a problem submitting your request: ${error}. Check your network connection and try again.`, 'Unexpected error');
+			this.showModal(`There was a problem submitting your request: ${error}. Check your network connection and try again.`, 'Unexpected error');
 		}).always(() => {
 			hideLoadingIndicator()
 		})
@@ -292,10 +292,10 @@ class ClimberDBIndex extends ClimberDB {
 					//	open the regular log-in page
 					window.location.href = $('#set-password-button').data('target') || window.location.pathname;
 				} else {
-					showModal(`There was a problem setting your password. Make sure you're still connected to the NPS network and try again. Contact your database adminstrator if the problem persists.`, 'Database Error');
+					this.showModal(`There was a problem setting your password. Make sure you're still connected to the NPS network and try again. Contact your database adminstrator if the problem persists.`, 'Database Error');
 				}
 			}).fail((xhr, error, status) => {
-				showModal(`An unexpected error occurred while saving data to the database: ${error}. Make sure you're still connected to the NPS network and try again. Contact your database adminstrator if the problem persists.`, 'Unexpected error');
+				this.showModal(`An unexpected error occurred while saving data to the database: ${error}. Make sure you're still connected to the NPS network and try again. Contact your database adminstrator if the problem persists.`, 'Unexpected error');
 			}).always(() => {this.toggleDotLoadingIndicator($buttonContainer, {hide: true});})
 		})
 	}

--- a/web/js/query.js
+++ b/web/js/query.js
@@ -1119,7 +1119,7 @@ class ClimberDBQuery extends ClimberDB {
 			$target.val($target.data('current-value'));
 			const message = `The "${otherLabelText}" field ${targetIsGroupBy ? 'is already set to' : 'already includes'} "${otherValueText}". Either` + 
 				` choose a different "${targetLabelText}" value or change the "${otherLabelText}" value.`;
-			showModal(message, `Invalid ${targetLabelText} value`);
+			this.showModal(message, `Invalid ${targetLabelText} value`);
 		}
 
 		// when the group by or pivot field is backcountry_location_codes, make sure is_backcountry_yes_no is set
@@ -1334,7 +1334,7 @@ class ClimberDBQuery extends ClimberDB {
 			const message = `The field <strong>${firstErrorFieldName}</strong> must be filled` +
 				' in before you can run this query.';
 			const eventHandler = () => {$('#alert-modal .confirm-button').click(() => {$firstErrorField.focus()})}
-			showModal(message, 'Missing Parameter', 'alert', '', {eventHandlerCallable: eventHandler})
+			this.showModal(message, 'Missing Parameter', {modalType: 'alert', eventHandlerCallable: eventHandler})
 			$errors.removeClass('error');
 		}
 
@@ -1520,7 +1520,7 @@ class ClimberDBQuery extends ClimberDB {
 			where = ' WHERE ' + whereClauses.join(' AND ');
 		}
 		if (where.length == 0) {
-			showModal('You must enter an expedition name search string or select a year or expedition ID', 'No Query Parameters')
+			this.showModal('You must enter an expedition name search string or select a year or expedition ID', 'No Query Parameters')
 			return;
 		}
 
@@ -1915,7 +1915,7 @@ class ClimberDBQuery extends ClimberDB {
 			}	
 		}).fail( (xhr, status, error) => {
 			$('#exports-modal').modal('hide');
-			showModal(`An unexpected error occurred while exporting the data: ${error}.${this.getDBContactMessage()}`, 'Unexpected Error');
+			this.showModal(`An unexpected error occurred while exporting the data: ${error}.${this.getDBContactMessage()}`, 'Unexpected Error');
 		}).always(() => {
 			hideLoadingIndicator();
 		})

--- a/web/js/query.js
+++ b/web/js/query.js
@@ -691,8 +691,8 @@ class ClimberDBQuery extends ClimberDB {
 			this.onGroupByPivotFieldChange(e);
 		})
 
-		$('#copy-query-link-button').click(() => {
-			this.onCopyQueryLinkButtonClick()
+		$('#copy-query-link-button').click(e => {
+			this.onCopyQueryLinkButtonClick(e)
 		})
 	}
 
@@ -2029,9 +2029,13 @@ class ClimberDBQuery extends ClimberDB {
 	/*
 	Event handler for copy-query-link-button click
 	*/
-	onCopyQueryLinkButtonClick() {
+	onCopyQueryLinkButtonClick(e) {
 		const url = this.queryToURL();
-		this.copyToClipboard(url, `Permalink for this query successfully copied to clipboard`);
+		this.copyToClipboard(
+			url, 
+			{
+				modalMessage: `Permalink for this query successfully copied to clipboard`
+			});
 	}
 
 

--- a/web/js/users.js
+++ b/web/js/users.js
@@ -142,7 +142,7 @@ class ClimberDBUsers extends ClimberDB {
 		if (matchedUsers.length) {
 			const status = matchedUsers[0].user_status_code;
 			const matchedUserID = matchedUsers[0].id;
-			var message = `The user ${username} already exists `
+			var message = `The user <strong>${username}</strong> already exists `
 			var footerButtons = '';
 			if (status == -1) {
 				message += `but the account is currently disabled. Would you like to enable it?`;
@@ -166,7 +166,7 @@ class ClimberDBUsers extends ClimberDB {
 				footerButtons = '';
 			}
 			
-			showModal(message, 'Duplicate username', 'confirm', footerButtons);
+			this.showModal(message, 'Duplicate username', {footerButtons: footerButtons});
 		}
 	}
 
@@ -209,7 +209,7 @@ class ClimberDBUsers extends ClimberDB {
 				footerButtons = '';
 			}
 			
-			showModal(message, 'Duplicate user', 'confirm', footerButtons, {eventHandlerCallable: onConfirmClickHandler});
+			this.showModal(message, 'Duplicate user', {footerButtons: footerButtons, eventHandlerCallable: onConfirmClickHandler});
 		}
 	}
 
@@ -358,7 +358,7 @@ class ClimberDBUsers extends ClimberDB {
 		const $table = $($(e.target).closest('button').data('target'))
 		// if there's already a new user, force the user to save or discard that one
 		if ($table.find('.new-user').length) {
-			showModal('You already created a new user. Either save those changes or delete that user before creating another one.', 'Save Error');
+			this.showModal('You already created a new user. Either save those changes or delete that user before creating another one.', 'Save Error');
 			return;
 		}
 		// If the user is currently editing
@@ -384,7 +384,7 @@ class ClimberDBUsers extends ClimberDB {
 		const $inputs = $tr.find('.input-field.dirty');
 
 		if (!$inputs.length) {
-			showModal('You have not yet made any edits to save.', 'No edits to save');
+			this.showModal('You have not yet made any edits to save.', 'No edits to save');
 			return;
 		}
 
@@ -462,18 +462,18 @@ class ClimberDBUsers extends ClimberDB {
 						}).done(resultString => {
 							const pythonError = this.pythonReturnedError(resultString);
 							if (pythonError !== false) {
-								showModal(`Account activation email failed to send with the error:\n${pythonError.trim()}.\nYou can send the activation link directly to ${firstName}: <br><a href="${activationURL}">${activationURL}</a>`, 'Email Server Error')
+								this.showModal(`Account activation email failed to send with the error:\n${pythonError.trim()}.\nYou can send the activation link directly to ${firstName}: <br><a href="${activationURL}">${activationURL}</a>`, 'Email Server Error')
 							} else {
-								showModal(`An activation email was successfully sent to ${email} with the activation link <a href="${activationURL}">${activationURL}</a>. The account will not be active until ${firstName} completes the activation process.`, 'Activation Email Sent')
+								this.showModal(`An activation email was successfully sent to ${email} with the activation link <a href="${activationURL}">${activationURL}</a>. The account will not be active until ${firstName} completes the activation process.`, 'Activation Email Sent')
 							}
 						}).fail((xhr, status, error) => { 
-							showModal(`Account activation email failed to send with the error: ${error}. You can send the activation link directly to the user whose account you just created: <br><a href="${activationURL}">${activationURL}</a>`, 'Email Server Error')
+							this.showModal(`Account activation email failed to send with the error: ${error}. You can send the activation link directly to the user whose account you just created: <br><a href="${activationURL}">${activationURL}</a>`, 'Email Server Error')
 						})
 					}
 				}
 			}
 		}).fail((xhr, status, error) => {
-			showModal(`An unexpected error occurred while saving data to the database: ${error}.${this.getDBContactMessage()}`, 'Unexpected error');
+			this.showModal(`An unexpected error occurred while saving data to the database: ${error}.${this.getDBContactMessage()}`, 'Unexpected error');
 			// roll back in-memory data
 		}).always(() => {
 		 	climberDB.hideLoadingIndicator();
@@ -537,12 +537,13 @@ class ClimberDBUsers extends ClimberDB {
 			<button class="generic-button modal-button primary-button confirm-button close-modal" data-dismiss="modal">Save</button>
 		`;
 
-		showModal(
+		this.showModal(
 			`You have unsaved edits to this user. Would you like to <strong>Save</strong> or <strong>Discard</strong> them? Click <strong>Cancel</strong> to continue editing this user.`,
 			'Save edits?',
-			'alert',
-			footerButtons,
-			{eventHandlerCallable: onClickHandler}
+			{
+				footerButtons: footerButtons,
+				eventHandlerCallable: onClickHandler
+			}
 		);
 	}
 
@@ -571,7 +572,7 @@ class ClimberDBUsers extends ClimberDB {
 					` <a href="mailto:${this.config.db_admin_email}">Contact your database` +
 					` adminstrator</a> if the problem persists. Full error: <br><br>Could not ` +
 					` save edits because table-id is null`;
-				showModal(message, 'Unexpected error');
+				this.showModal(message, 'Unexpected error');
 				return;
 			}
 			const formData = new FormData()
@@ -592,7 +593,7 @@ class ClimberDBUsers extends ClimberDB {
 					$userRow.fadeRemove()
 				}
 			}).fail((xhr, status, error) => {
-				showModal('Database Error', 'The user could not be disabled because the system encountered an unexpected error: <br><br>' + error)
+				this.showModal('Database Error', 'The user could not be disabled because the system encountered an unexpected error: <br><br>' + error)
 			});
 		}
 	}
@@ -611,7 +612,7 @@ class ClimberDBUsers extends ClimberDB {
 			cache: false
 		}).done(resultString => {
 			if (!this.pythonReturnedError(resultString, {errorExplanation: 'The password reset email failed to send because of an unexpected error.'})) {
-				showModal(`A password reset email was sent to ${email_address}. The user's account will be inactive until they change their password.`, 'Password reset email sent');
+				this.showModal(`A password reset email was sent to ${email_address}. The user's account will be inactive until they change their password.`, 'Password reset email sent');
 				$(`tr[data-table-id=${userID}]`).addClass('inactive')
 					.find('.input-field[name=user_status_code]')
 						// set status to "inactive" in the UI but don't worry about saving because it's already doen server-side
@@ -619,7 +620,7 @@ class ClimberDBUsers extends ClimberDB {
 						//.change(); 
 			}
 		}).fail((xhr, status, error) => { 
-			showModal(`Password reset email failed to send with the error: ${error}.${this.getDBContactMessage()}`, 'Email Server Error')
+			this.showModal(`Password reset email failed to send with the error: ${error}.${this.getDBContactMessage()}`, 'Email Server Error')
 		});
 	}
 
@@ -631,7 +632,7 @@ class ClimberDBUsers extends ClimberDB {
 
 		const $tr = $('tbody tr:not(.uneditable)');
 		if ($tr.is('.new-user')) {
-			showModal('This is a new user so their password does not need to be reset. To send an activation email to the user, click the "Save" button', 'Invalid action');
+			this.showModal('This is a new user so their password does not need to be reset. To send an activation email to the user, click the "Save" button', 'Invalid action');
 			return;
 		}
 
@@ -648,7 +649,10 @@ class ClimberDBUsers extends ClimberDB {
 		const onConfirmClick = () => {$('#alert-modal .confirm-button').click(() => {
 			this.sendPasswordResetEmail(username, userID, email_address)
 		})}
-		showModal(`Are you sure want to reset ${firstName}'s password? If you click 'Yes', ${firstName} will receive an email at ${email_address} with a link to reset their password, but their account will be suspended until they reset it.`, 'Send password reset email?', 'confirm', footerButtons, {eventHandlerCallable: onConfirmClick});
+		const message = `Are you sure want to reset ${firstName}'s password? If you click` + 
+			` 'Yes', ${firstName} will receive an email at ${email_address} with a link to` +
+			' reset their password, but their account will be suspended until they reset it.';
+		this.showModal(message, 'Send password reset email?', {footerButtons: footerButtons, eventHandlerCallable: onConfirmClick});
 	}
 
 


### PR DESCRIPTION
These changes make several improvements:
1. Adds email notifications via a `logging.handler.SMTPHandler`. An optional `ERROR_NOTIFICATION_RECIPIENTS` can be specified in the `climberdb_config.json` file. If it doesn't exist, the fallback value is the `DB_ADMIN_EMAIL` property.
2. Modifies the display of an unexpected Python error in a modal message to show the full error message in a collapse that the user can optionally expand so that the they aren't overwhelmed by it
3. Adds an optional `errorExplanation` argument to the `.pythonReturnedError()` abstract class method. If present, the method will present the modal message itself with a the explanation provided and standardized text appended with an additional helper method, `.getDBContactMessage()`
4.  Adds a "copy error" button so the user can easily copy the whole text of the error
5. Modal messages are processed in a queue as a more robust way to handle cases where successive message are sent that should be displayed one at a time, as the user dismisses each one
6. Adds an endpoint to trigger an error for testing purposes. The endpoint is POST-only and requires the `TEST_CLIENT_SECRET`. Future endpoints to `/flask/test/...` should also require the secret for authentication

This PR also adds a logging configuration module for Flask, but I can't get logging to work when the config function is imported from another module. I added the module for posterity, but it's not used in the final code. The function is just defined in `climberdb.py` instead