### PR TITLE
Add pwd reset email on reactivation issue 122

### DIFF
--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -196,6 +196,7 @@ def test_error_logging() -> bool:
 
 	return True
 
+
 @app.route('/flask/environment', methods=['GET'])
 def get_environment() -> str:
 	return climberdb_utils.get_environment()
@@ -327,14 +328,6 @@ def add_header(response):
 ###############################################
 # -------------- endpoints ------------------ #
 ###############################################
-# **for testing**
-@app.route('/flask/test', methods=['GET', 'POST'])
-def test():
-
-	if request.files:
-		return 'true'
-	else:
-		return 'false'
 
 @app.route('/flask/config', methods=['POST'])
 def db_config_endpoint():
@@ -493,6 +486,23 @@ def send_password_email(request_data, html):
 	mailer.send(msg)
 
 
+def get_url_root(url_root) -> str:
+	"""
+	Helper function to sanitize the URL root to always return a URL for 
+	the prod site, even if the request is coming from dev or test. This 
+	prevents users from receiving a link to anything but prod in an 
+	activation or password reset email, even if it was sent from the 
+	something other than prod
+	"""
+	prod_port = str(app.config['PROD_PORT_NUMBER'])
+	url_root = re.sub(
+		':\d{4}$', 
+		f':{prod_port}', 
+		request.url_root.strip('/')
+	)
+	return url_root
+
+
 # This endpoint sends an activation notification to a user whose account was just created by an admin
 @app.route('/flask/notifications/account_activation', methods=['POST'])
 def send_account_request():
@@ -503,8 +513,9 @@ def send_account_request():
 	if not 'username' in data:
 		raise ValueError('BAD REQUEST. No username given')
 
+	user_id = data['user_id']
 	data['logo_base64_string'] = 'data:image/jpg;base64,' + get_email_logo_base64()	
-	data['button_url'] = f'''{request.url_root.strip('/')}/index.html?activation=true&id={data['user_id']}'''
+	data['button_url'] = f'''{get_url_root(request.url_root)}/index.html?activation=true&id={user_id}'''
 	data['button_text'] = 'Activate Account'
 	data['heading_title'] = 'Activate your Denali Climbing Permit Portal account'
 
@@ -528,7 +539,7 @@ def send_reset_password_request():
 
 	user_id = data['user_id']
 	data['logo_base64_string'] = 'data:image/jpg;base64,' + get_email_logo_base64()	
-	data['button_url'] = f'''{request.url_root.strip('/').replace(':9006', ':9007')}/index.html?reset=true&id={user_id}'''
+	data['button_url'] = f'''{get_url_root(request.url_root)}/index.html?reset=true&id={user_id}'''
 	data['button_text'] = 'Reset Password'
 	data['heading_title'] = 'Reset Denali Climbing Permit Portal account password'
 

--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -547,9 +547,12 @@ def send_reset_password_request():
 	
 	send_password_email(data, html)
 
-	#engine = climberdb_utils.get_engine()
 	try:
-		write_engine.execute(sqlatext('UPDATE users SET user_status_code=1 WHERE id=:user_id'), {'user_id': user_id})
+		# Set the user's status to 'Inactive'
+		with WriteSession() as write_session:
+			user = write_session.get(tables['users'], user_id)
+			user.user_status_code = 1 # set to inactive
+			write_session.commit()
 	except Exception as e:
 		raise RuntimeError(f'Failed to update user status with error: {e}')
 

--- a/web/js/users.js
+++ b/web/js/users.js
@@ -153,12 +153,12 @@ class ClimberDBUsers extends ClimberDB {
 					$('#alert-modal .confirm-button').click(() => {
 						this.discardEdits(); //remove new user
 						const $tr = $(`#main-data-table tbody tr[data-table-id=${matchedUserID}]`);
-						// set user status code to 'enabled' for matched user
-						$tr.ariaHide(false)
-							.removeClass('uneditable')
-							.find('.input-field[name=user_status_code]')
-								.val(2)
-								.change();
+						// Send password reset email to user. If successful, the method 
+						//	will handle setting the user's status to inactive, both on 
+						//	the client and server sideog
+						const userID = $tr.data('table-id');
+						const email_address = $tr.find('.input-field[name="email_address"]').val();
+						this.sendPasswordResetEmail(username, userID, email_address);
 					});
 				}
 			} else {
@@ -613,6 +613,7 @@ class ClimberDBUsers extends ClimberDB {
 			if (!this.pythonReturnedError(resultString, {errorExplanation: 'The password reset email failed to send because of an unexpected error.'})) {
 				this.showModal(`A password reset email was sent to ${email_address}. The user's account will be inactive until they change their password.`, 'Password reset email sent');
 				$(`tr[data-table-id=${userID}]`).addClass('inactive')
+					.ariaHide(false)
 					.find('.input-field[name=user_status_code]')
 						// set status to "inactive" in the UI but don't worry about saving because it's already doen server-side
 						.val(1) 

--- a/web/js/users.js
+++ b/web/js/users.js
@@ -175,7 +175,10 @@ class ClimberDBUsers extends ClimberDB {
 		const firstName = $tr.find('.input-field[name=first_name]').val();
 		const lastName = $tr.find('.input-field[name=last_name]').val();
 		const matchedUsers = Object.values(this.users)
-			.filter(u => u.first_name === firstName && u.last_name === lastName);
+			.filter(u => 
+				u.first_name.toLowerCase() === firstName.toLowerCase() && 
+				u.last_name.toLowerCase()  === lastName.toLowerCase()
+			);
 		var onConfirmClickHandler = () => {};
 		
 		if (matchedUsers.length) {
@@ -186,15 +189,15 @@ class ClimberDBUsers extends ClimberDB {
 			if (status == -1) {
 				message += `but the account is currently disabled. Would you like to enable it?`;
 				onConfirmClickHandler = () => {
-					('#alert-modal .confirm-button').click(() => {
+					$('#alert-modal .confirm-button').click(() => {
 						this.discardEdits(); //remove new user
 						const $tr = $(`.climberdb-data-table tbody tr[data-table-id=${matchedUserID}]`);
-						// set user status code to 'enabled' for matched user
+						// set user status code to 'inactive' for matched user
 						// 	this will do nothing for non-login users since there is no status field
 						$tr.ariaHide(false)
 							.removeClass('uneditable')
 							.find('.input-field[name=user_status_code]')
-								.val(2)
+								.val(1)
 								.change();
 					});
 				}


### PR DESCRIPTION
Made a few small improvements in addition to addressing the original issue:
1. root URL can now be obtained from a helper function to ensure it will always return the prod URL, even when testing on dev. This is so that if I (or anyone else with dev access) accidentally reset a user's password, the reset link will be to the prod site. The prod port is also stored in the config file rather than in the code
2. When the user's status is updated in the DB, `climerbdb.py` now uses the ORM. This way, the correct schema will always be updated
3. When comparing first and last names to determine if the user is creating a duplicate user account, compare all strings as lower case

Also fixed one small bug in users.js, line 192: jQuery (`$`) wasn't being called on element selector