### PR TITLE
use a clone_views()-proof method for getting attachment path

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -524,7 +524,7 @@ CREATE OR REPLACE VIEW expedition_info_view AS
 		attachments.attachment_notes,
 		attachments.client_filename,
 		attachments.mime_type,
-		'attachments/' || split_part(attachments.file_path, '\', -1) AS file_path, --'
+		(regexp_match(attachments.file_path, '\w+\\[\w-]+\.\w{3,4}$'))[1] AS file_path, --'get jsut folder\file.ext
 		attachments.file_size_kb,
 		cmc_checkout.id AS cmc_checkout_id,
 		cmc_checkout.cmc_id,


### PR DESCRIPTION
`clone_views()` finds all occurrences table names in view's query string and replaces them. Setting the `file_path` of `expedition_info_view` with `'attachments/' || ...`, the path in the `dev` schema's view would actually start with `'dev.attachments/'`. Using a regex not only solves this problem, but it's also more future-proof in case the attachments directory changes.