### PR TITLE
Fix 60 day warning

### DIFF
--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -4767,13 +4767,19 @@ class ClimberDBExpeditions extends ClimberDB {
 				(groupStatusCode === 1 || groupStatusCode === 2) && //group is not confirmed
 				(climbingFeesNotPaid || supsNotComplete || psarNotComplete)
 			) {
-			const newDepartureDate = new Date(departureDate.getTime() + this.constants.millisecondsPerDay * 60)
+			const now = new Date();
+			const newDepartureDate = new Date(now.getTime() + this.constants.millisecondsPerDay * 60)
 				.toLocaleDateString('en-US', {month: 'long', day: 'numeric'});
 			let reasons = '';
 			if (climbingFeesNotPaid) reasons += `<li>${nClimbingFeesNotPaid} climber${nClimbingFeesNotPaid > 1 ? 's have' : ' has'} not paid their climbing permit fee</li>`;
 			if (supsNotComplete) 	 reasons += `<li>${nSUPsNotComplete} climber${nSUPsNotComplete > 1 ? 's have' : ' has'} not submitted their SUP application</li>`;
 			if (psarNotComplete)	 reasons += `<li>${nPSARNotComplete} climber${nPSARNotComplete > 1 ? 's have' : ' has'} not submitted their PSAR form</li>`;
-			const message = `This expedition is 60 days or less from their scheduled departure date on <strong>${departureDate.toLocaleDateString('en-US', {month: 'long', day: 'numeric'})}</strong>, but not all expedition members have completed the requirements to receive a permit. These unfulfilled requirements include: <ul>${reasons}</ul>You should verify that these requirements have not been fulfilled, and if not, change the groups departure date to on or after <strong>${newDepartureDate}</strong>.`;
+			const message = `This expedition is 60 days or less from their scheduled departure date on` + 
+				`<strong>${departureDate.toLocaleDateString('en-US', {month: 'long', day: 'numeric'})}</strong>` + 
+				`, but not all expedition members have completed the requirements to receive a permit. These` + 
+				` unfulfilled requirements include: <ul>${reasons}</ul>You should verify that these` +
+				` requirements have not been fulfilled, and if not, change the groups departure date` + 
+				` to on or after <strong>${newDepartureDate}</strong>.`;
 			this.showModal(message, 'WARNING: 60-Day Rule Violation');
 		}
 	}

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -4755,7 +4755,7 @@ class ClimberDBExpeditions extends ClimberDB {
 		}
 
 		const groupStatusCode = parseInt($('#input-group_status').val());
-		const $cards = $('#expedition-members-accordion .card:not(.cancelled)');
+		const $cards = $('#expedition-members-accordion .card:not(.cancelled):not(.cloneable)');
 		const nClimbingFeesNotPaid = $cards.find('.climbing-fee-icon.transparent').length;
 		const nSUPsNotComplete = $cards.find('.input-field[name=application_complete]:not(:checked)').length;
 		const nPSARNotComplete = $cards.find('.input-field[name=psar_complete]:not(:checked)').length;


### PR DESCRIPTION
was previously including `.cloneable` card so any pending expedition with a departure date < 60 days away was triggering the warning. Also, the new departure date the warning showed was incorrectly calculated as `planned_departure_date` + 60 days instead of 60 days from now.