### PR TITLE
include user.id in returned result

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -1082,7 +1082,7 @@ $BODY$
 		ORDER BY sort_order, table_name
 	LOOP
 		view_name := dest_schema || '.' || quote_ident(record_.table_name);
-		EXECUTE 'DROP VIEW IF EXISTS ' || view_name || ' CASCADE; CREATE VIEW ' || view_name || ' AS ' || record_.view_def || ';' ;
+		EXECUTE 'CREATE OR REPLACE VIEW ' || view_name || ' AS ' || record_.view_def || ';' ;
 	END LOOP;
   
 	RETURN; 

--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -341,6 +341,7 @@ def query_user_info(username):
 
 	users_table = tables['users'];
 	statement = select(
+			users_table.id,
 			users_table.user_role_code,
 			users_table.user_status_code,
 			users_table.first_name,


### PR DESCRIPTION
hot fix: when I changed `query_user_info()` in `climberdb.py` to use an ORM query (PR #125), I accidentally excluded the user ID