### PR TITLE
remove 60 day warning

### DIFF
--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -3968,7 +3968,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				// If any expedition members have been flagged, notify the user so they'll be prompted to look at the comments
 				if (showOnLoadWarnings) {
 					this.showFlaggedMemberWarning();
-					this.show60DayWarning();
+					//this.show60DayWarning();
 				}
 			}
 		}).fail((xhr, status, error) => {


### PR DESCRIPTION
staff said this isn't necessary. I just commented it out so it can be added back in easily if desired later on