### PR TITLE
Fix onunload alert shows after save issue 176

### DIFF
--- a/web/js/climberdb.js
+++ b/web/js/climberdb.js
@@ -2152,12 +2152,9 @@ class ClimberDB {
 	*/
 	beforeUnloadEventHandler(e) {
 		
-		//if ($('.input-field.dirty:not(.filled-by-default)').length) {
 		e.preventDefault();
 		const message = 'You have unsaved edits. Are you sure you want to leave this page?';
 		e.returnValue = message;
-		//return message;
-		//}
 	}
 
 
@@ -2168,10 +2165,17 @@ class ClimberDB {
 	*/	
 	toggleBeforeUnload(shouldTurnOn=false) {
 
+		// To ensure only one beforeunload event is registered, store the event 
+		//	as a class property
+		if (!this._beforeUnloadHandler) {
+			this._beforeUnloadHandler = (e) => this.beforeUnloadEventHandler(e);
+		}
+
+		// register/de-register the stored handler
 		if (shouldTurnOn) {
-			$(window).on('beforeunload', (e) => {this.beforeUnloadEventHandler(e)});
+			window.addEventListener('beforeunload', this._beforeUnloadHandler);
 		} else {
-			$(window).off('beforeunload');
+			window.removeEventListener('beforeunload', this._beforeUnloadHandler);
 		}
 	}
 

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -3689,6 +3689,10 @@ class ClimberDBExpeditions extends ClimberDB {
 
 		// Toggle the is_guiding collapse
 		$('#input-guide_company').change();
+
+		// Make sure the beforeunload event is turned off since it was likely 
+		//	turned on by manual change events
+		this.toggleBeforeUnload(false);
 	}
 
 


### PR DESCRIPTION
This was only a problem on the backcountry page. It was likely because some input didn't have a utility class, but I think these fixes are good in general because the beforeunload alert shouldn't appear in any event after filling field values