### PR TITLE
remove modal message prompting user to add attachment when SUP/PSAR box checked

### DIFF
--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -355,9 +355,9 @@ class ClimberDBExpeditions extends ClimberDB {
 		});
 
 		// Ask the user if they want to add an attachment
-		$(document).on('change', '.file-submission-checkbox', e => {
-			this.onFileSubmissionCheckboxChange(e);
-		});
+		// $(document).on('change', '.file-submission-checkbox', e => {
+		// 	this.onFileSubmissionCheckboxChange(e);
+		// });
 
 		$(document).on('click', '.change-expedition-button', e => {
 			this.showChangeExpeditionModal($(e.target).closest('.card'));


### PR DESCRIPTION
staff not using attachments for now so just remove the prompt