### PR TITLE
Add bc route to itinerary locations issue 149

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -42,6 +42,16 @@ CREATE TABLE transaction_type_codes (
 CREATE TABLE IF NOT EXISTS user_role_codes(id SERIAL PRIMARY KEY, name VARCHAR(50) UNIQUE, code INTEGER UNIQUE, sort_order INTEGER);
 CREATE TABLE IF NOT EXISTS user_status_codes (id SERIAL PRIMARY KEY, name varchar(50) UNIQUE, code INTEGER UNIQUE, sort_order INTEGER);
 
+-- create a cross-ref table for the many-to-many relationship between 
+--	backcountry locations and mountains. This relationship allows
+--	different backcountry locations to be associated with overlapping
+--	sets of mountains that might also contain unique memebers
+CREATE TABLE IF NOT EXISTS dev.backcountry_locations_mountains_xref (
+	backcountry_location_code INTEGER REFERENCES backcountry_location_codes(code) ON UPDATE CASCADE ON DELETE RESTRICT,
+	mountain_code INTEGER REFERENCES mountain_codes(code) ON UPDATE CASCADE ON DELETE RESTRICT,
+	PRIMARY KEY (backcountry_location_code, mountain_code)
+);
+
 --Create data tables
 CREATE TABLE IF NOT EXISTS climbers (
 	id SERIAL PRIMARY KEY,
@@ -173,12 +183,29 @@ CREATE TABLE IF NOT EXISTS attachments (
 	entered_by VARCHAR(50), 
 	last_modified_time TIMESTAMP, 
 	last_modified_by VARCHAR(50)
-)
+);
+
+CREATE TABLE IF NOT EXISTS itinerary_locations (
+	id SERIAL PRIMARY KEY,
+	expedition_id INTEGER NOT NULL REFERENCES expeditions(id) ON UPDATE CASCADE ON DELETE CASCADE,
+	backcountry_location_type_code INTEGER REFERENCES backcountry_location_type_codes(code) ON UPDATE CASCADE ON DELETE RESTRICT,
+	backcountry_location_code INTEGER REFERENCES backcountry_location_codes(code) ON UPDATE CASCADE ON DELETE RESTRICT,
+	location_start_date DATE,
+	location_end_date DATE,
+	latitude NUMERIC(10, 7),
+	longitude NUMERIC(10, 7), 
+	display_order INTEGER,	
+	entered_by VARCHAR(50),
+	entry_time TIMESTAMP,
+	last_modified_by VARCHAR(50),
+	last_modified_time TIMESTAMP
+);
 
 CREATE TABLE IF NOT EXISTS expedition_member_routes (
 	id SERIAL PRIMARY KEY,
 	expedition_member_id INTEGER NOT NULL REFERENCES expedition_members(id) ON UPDATE CASCADE ON DELETE CASCADE,
 	route_code INTEGER REFERENCES route_codes(code) ON UPDATE CASCADE ON DELETE RESTRICT,
+	itinerary_location_id REFERENCES itinerary_locations(id) ON UPDATE CASCADE ON DELETE SET NULL, --
 	route_order INTEGER,
 	route_was_summited BOOLEAN, --a null summit_date could indicate that the route wasn't climbed, but I don't think you could rely on it
 	highest_elevation_ft INTEGER,
@@ -234,22 +261,6 @@ CREATE TABLE IF NOT EXISTS communication_devices (
 	expedition_member_id INTEGER REFERENCES expedition_members(id) ON UPDATE CASCADE ON DELETE CASCADE,
 	communication_device_type_code INTEGER REFERENCES communication_device_type_codes(code) ON UPDATE CASCADE ON DELETE RESTRICT,
 	number_or_address VARCHAR(255),
-	entered_by VARCHAR(50),
-	entry_time TIMESTAMP,
-	last_modified_by VARCHAR(50),
-	last_modified_time TIMESTAMP
-);
-
-CREATE TABLE IF NOT EXISTS itinerary_locations (
-	id SERIAL PRIMARY KEY,
-	expedition_id INTEGER NOT NULL REFERENCES expeditions(id) ON UPDATE CASCADE ON DELETE CASCADE,
-	backcountry_location_type_code INTEGER REFERENCES backcountry_location_type_codes(code) ON UPDATE CASCADE ON DELETE RESTRICT,
-	backcountry_location_code INTEGER REFERENCES backcountry_location_codes(code) ON UPDATE CASCADE ON DELETE RESTRICT,
-	location_start_date DATE,
-	location_end_date DATE,
-	latitude NUMERIC(10, 7),
-	longitude NUMERIC(10, 7), 
-	display_order INTEGER,	
 	entered_by VARCHAR(50),
 	entry_time TIMESTAMP,
 	last_modified_by VARCHAR(50),
@@ -513,6 +524,7 @@ CREATE OR REPLACE VIEW expedition_info_view AS
 		expedition_member_routes.route_was_summited,
 		expedition_member_routes.summit_date,
 		expedition_member_routes.highest_elevation_ft,
+		expedition_member_routes.itinerary_location_id AS expedition_member_routes_itinerary_location_id, -- prevent collision with itinerary_location table's id field
 		transactions.transaction_type_code,
 		transactions.transaction_value,
 		transactions.transaction_notes,

--- a/web/backcountry.html
+++ b/web/backcountry.html
@@ -515,8 +515,44 @@
 
 							</div>
 						</div>
-						<!-- routes -->
-						<div id="routes-data-container" class="d-flex flex-wrap w-100 mt-5">
+
+						<!-- comms -->
+						<div id="comms-data-container" class="d-flex flex-wrap w-100 mt-5">
+							<div class="expedition-data-header-container">
+								<h3 id="expedition-data-header" class="expedition-data-header">Comms Devices</h3>
+								<button class="generic-button add-data-button add-comms-button" data-target="#comms-list" title="Add comms">Add comms</button>
+							</div>
+							<div class="expedition-data-content-body">
+								<div class="data-list-item data-list-item-header">
+									<label class="data-list-col data-list-header-label col-3">Device type</label>
+									<label class="data-list-col data-list-header-label col-4">Number/address</label>
+									<label class="data-list-col data-list-header-label col-3">Device owner</label>
+									<label class="data-list-col data-list-header-label col-1"></label>
+								</div>
+								<ul id="comms-list" class="data-list cmc-list">
+									<li class="data-list-item show-children-on-hover cloneable hidden">
+										<div class="cmc-col col-3">
+											<select id="input-communication_device_type" class="input-field default" name="communication_device_type_code" data-table-name="communication_devices" title="Device Type" placeholder="Device type" required="required"></select>
+											<span class="required-indicator">*</span>
+										</div>
+										<div class="cmc-col col-4">
+											<input id="input-number_or_address" class="input-field" name="number_or_address" data-table-name="communication_devices" title="Device number/address" autocomplete="__never"> 
+										</div>
+										<div class="cmc-col col-3">
+											<select id="input-owner" class="input-field no-option-fill default" name="expedition_member_id" data-table-name="communication_devices" title="Device owner"></select>
+										</div>
+										<div class="col-1 list-item-delete-button-container">
+											<button class="icon-button delete-button delete-comms-button show-on-parent-hover" title="Delete comms">
+												<i class="fas fa-trash fa-lg"></i>
+												<label class="icon-button-label">delete</label>
+											</button>
+										</div>
+									</li>
+								</ul>
+							</div>
+						</div>
+						<!-- routes -- hidden from user because routes are included in locations card for BC-->
+						<div id="routes-data-container" class="d-flex flex-wrap w-100 mt-5 hidden" aria-hidden="true">
 								<div class="expedition-data-header-container">
 									<div class="d-flex">
 										<button class="expand-card-button icon-button" aria-label="Expand expedition members content" title="Expand expedition members content">
@@ -532,7 +568,7 @@
 										<div id="cloneable-card-routes" class="card expedition-card cloneable hidden" >
 											<div class="card-header show-children-on-hover" id="cardHeader-routes-cloneable">
 												<div class="col-3 pr-0 d-flex">
-													<select id="mountain-code-header-input" class="input-field card-link-label route-code-header-input mountain-code-header-input expedition-member-card-link-label" name="mountain_code">
+													<select id="mountain-code-header-input" class="input-field card-link-label route-code-header-input mountain-code-header-input expedition-member-card-link-label no-option-fill" name="mountain_code">
 														<option value="">Select mountain</option>
 													</select>
 												</div>
@@ -565,6 +601,7 @@
 															<!-- route_code and route_order inputs are hidden because the select in the .card-header controls the value for all of them-->
 															<input id="input-route_code" class="input-field hidden" type="number" name="route_code" data-table-name="expedition_member_routes">
 															<input id="input-route_order" class="input-field hidden" type="number" name="route_order" data-table-name="expedition_member_routes">
+															<input id="input-itinerary_location_id" class="input-field hidden" type="number" name="itinerary_location_id" data-table-name="expedition_member_routes" data-foreign-table="itinerary_locations">
 															
 															<div class="col-4 route-member-name-column">
 																<label class="data-list-header-label name-label"></label>
@@ -610,8 +647,8 @@
 								<button id="add-location-button" class="generic-button add-data-button" data-target="#locations-accordion" title="Add location">Add location</button>
 							</div>
 							<div class="expedition-data-content-body">
-								<div id="locations-accordion" class="accordion" data-table-name="itinerary_locations" data-item-display-name="location">
-									<div id="cloneable-card-expedition-members" class="card expedition-card cloneable hidden">
+								<div id="locations-accordion" class="accordion" data-table-name="itinerary_locations" data-item-display-name="itinerary location">
+									<div id="cloneable-card-expedition-members" class="card expedition-card cloneable location-card hidden">
 										<div class="card-header show-children-on-hover justify-content-between" id="cardHeader-location-cloneable">
 											<a class="card-link collapsed col-10 pl-0" data-toggle="collapse" href="#collapse-location-cloneable" data-target="collapse-location-cloneable">
 												<h6 class="card-link-label col px-0">New location</h6>
@@ -620,7 +657,7 @@
 												<button class="zoom-to-location-button icon-button show-on-parent-hover" title="Zoom to location">
 													<i class="fa-solid fa-2xl fa-magnifying-glass-location"></i>
 												</button>
-												<button class="delete-card-button icon-button show-on-parent-hover" title="Delete location">
+												<button class="delete-card-button delete-location-button icon-button show-on-parent-hover" title="Delete location">
 													<i class="fa fa-trash"></i>
 												</button>
 												<i class="fa fa-chevron-down pull-right"></i>
@@ -665,7 +702,39 @@
 														<input id="input-location_display_order" class="input-field" name="display_order" type="number" placeholder="Display order" data-table-name="itinerary_locations"></select>
 													</div>
 												</div>
-
+												<div class="w-100 d-flex justify-content-between flex-wrap mt-3">
+													<h4 class="expedition-data-header">Routes For This Location</h4>
+													<button class="generic-button add-data-button add-bc-route-button" data-target="#bc-route-list" title="Add Route">Add Route</button>
+												</div>
+												<div>
+													<div class="data-list-item data-list-item-header">
+														<label class="data-list-col data-list-header-label col-3">Mountain/Objective</label>
+														<label class="data-list-col data-list-header-label col-4">Route Name</label>
+														<label class="data-list-col data-list-header-label col-1"></label>
+													</div>
+													<ul id="bc-route-list" class="data-list bc-route-list">
+														<li class="data-list-item cloneable show-children-on-hover hidden">
+															<div class="col-3 pr-0 d-flex">
+																<select id="bc-mountain-code" class="input-field bc-mountain-field no-option-fill keep-default-option ignore-changes" name="mountain_code" required="required">
+																	<option value="">Select mountain/objective</option>
+																</select>
+																<span class="required-indicator">*</span>
+															</div>
+															<div class="col-4 d-flex">
+																<select id="bc-route-code" class="input-field bc-route-field no-option-fill keep-default-option ignore-changes" name="route_code" required="required">
+																	<option value="">Select route</option>
+																</select>
+																<span class="required-indicator">*</span>
+															</div>
+															<div class="col-1 list-item-delete-button-container">
+																<button class="icon-button delete-button delete-bc-route-button show-on-parent-hover" title="Delete Route">
+																	<i class="fas fa-trash fa-lg"></i>
+																	<label class="icon-button-label">delete</label>
+																</button>
+															</div>
+														</li>
+													</ul>
+												</div>
 											</div>
 										</div>
 									</div> <!-- card -->
@@ -723,41 +792,6 @@
 							</div>
 						</div>
 
-						<!-- comms -->
-						<div id="comms-data-container" class="d-flex flex-wrap w-100 mt-5">
-							<div class="expedition-data-header-container">
-								<h3 id="expedition-data-header" class="expedition-data-header">Comms Devices</h3>
-								<button class="generic-button add-data-button add-comms-button" data-target="#comms-list" title="Add comms">Add comms</button>
-							</div>
-							<div class="expedition-data-content-body">
-								<div class="data-list-item data-list-item-header">
-									<label class="data-list-col data-list-header-label col-3">Device type</label>
-									<label class="data-list-col data-list-header-label col-4">Number/address</label>
-									<label class="data-list-col data-list-header-label col-3">Device owner</label>
-									<label class="data-list-col data-list-header-label col-1"></label>
-								</div>
-								<ul id="comms-list" class="data-list cmc-list">
-									<li class="data-list-item show-children-on-hover cloneable hidden">
-										<div class="cmc-col col-3">
-											<select id="input-communication_device_type" class="input-field default" name="communication_device_type_code" data-table-name="communication_devices" title="Device Type" placeholder="Device type" required="required"></select>
-											<span class="required-indicator">*</span>
-										</div>
-										<div class="cmc-col col-4">
-											<input id="input-number_or_address" class="input-field" name="number_or_address" data-table-name="communication_devices" title="Device number/address" autocomplete="__never"> 
-										</div>
-										<div class="cmc-col col-3">
-											<select id="input-owner" class="input-field no-option-fill default" name="expedition_member_id" data-table-name="communication_devices" title="Device owner"></select>
-										</div>
-										<div class="col-1 list-item-delete-button-container">
-											<button class="icon-button delete-button delete-comms-button show-on-parent-hover" title="Delete comms">
-												<i class="fas fa-trash fa-lg"></i>
-												<label class="icon-button-label">delete</label>
-											</button>
-										</div>
-									</li>
-								</ul>
-							</div>
-						</div>
 					</div>
 				</div>
 				<div class="w-100 d-flex justify-content-center hide-when-content-hidden">

--- a/web/backcountry.html
+++ b/web/backcountry.html
@@ -517,7 +517,7 @@
 						</div>
 
 						<!-- comms -->
-						<div id="comms-data-container" class="d-flex flex-wrap w-100 mt-5">
+						<!-- <div id="comms-data-container" class="d-flex flex-wrap w-100 mt-5">
 							<div class="expedition-data-header-container">
 								<h3 id="expedition-data-header" class="expedition-data-header">Comms Devices</h3>
 								<button class="generic-button add-data-button add-comms-button" data-target="#comms-list" title="Add comms">Add comms</button>
@@ -550,7 +550,7 @@
 									</li>
 								</ul>
 							</div>
-						</div>
+						</div> -->
 						<!-- routes -- hidden from user because routes are included in locations card for BC-->
 						<div id="routes-data-container" class="d-flex flex-wrap w-100 mt-5 hidden" aria-hidden="true">
 								<div class="expedition-data-header-container">

--- a/web/flask/climberdb.py
+++ b/web/flask/climberdb.py
@@ -44,6 +44,7 @@ from export_briefings import briefings_to_excel
 import threading
 import importlib
 
+
 def load_weasyprint():
     global weasyprint
     weasyprint = importlib.import_module('flask_weasyprint')
@@ -1649,6 +1650,37 @@ def save_config():
 	return response
 
 
+def delete_from_table(session:Session, table_name:str, id_list:[int], returning:dict={}) -> dict: 
+	
+	# For collecting values that would be in RETURNING clauses.
+	#	The dict is in the form { table_name: [{column: value}] }
+	returned = {}
+
+	table = tables.get(table_name)
+	if not table:
+		raise ValueError(f'The table "{table_name}" does not exist')
+
+	for table_id in id_list:
+		# Get the row by ID
+		row = session.get(table, table_id)	
+		# If a single ID was invalid, ROLLBACK the entire transaction
+		if not row:
+			raise RuntimeError(f'No {table_name} row with ID {table_id} found')
+		
+		if returning:
+			if not table_name in returned:
+				returned[table_name] = []
+			returned[table_name].append(
+				 {
+				 	column_name: climberdb_utils.sanitize_query_value(getattr(row, column_name)) 
+				 	for column_name in returning[table_name]
+				 } 
+			)
+		session.delete(row)
+
+	return returned
+
+
 @app.route('/flask/db/delete/by_id', methods=['POST'])
 def delete_by_id():
 
@@ -1671,36 +1703,44 @@ def delete_by_id():
 	except ValueError:
 		raise ValueError('Invalid ID in id_list: ' + str(ids))
 
-	table = tables.get(table_name)
-	if not table:
-		raise ValueError(f'The table "{table_name}" does not exist')
-
 	returning = request_data.get('returning')
-
-	# For collecting values that would be in RETURNING clauses.
-	#	The dict is in the form { table_name: [{column: value}] }
-	returned = {}
 
 	# Execute deletes within a transaction so an error will ROLLBACK 
 	#	any would-be successful deletes
 	with WriteSession() as session, session.begin():
-		for table_id in id_list:
-			# Get the row by ID
-			row = session.get(table, table_id)	
-			# If a single ID was invalid, ROLLBACK the entire transaction
-			if not row:
-				raise RuntimeError(f'No {table_name} row with ID {table_id} found')
-			
-			if returning:
-				if not table_name in returned:
-					returned[table_name] = []
-				returned[table_name].append(
-					 {
-					 	column_name: climberdb_utils.sanitize_query_value(getattr(row, column_name)) 
-					 	for column_name in returning[table_name]
-					 } 
-				)
-			session.delete(row)
+			returned = delete_from_table(session, table_name, id_list, returning)
+
+	return jsonify({
+		'data': returned
+	})
+
+
+@app.route('/flask/db/delete/from_multiple_tables', methods=['POST'])
+def delete_from_mutliple_tables():
+	request_data = request.get_json()
+
+	if not isinstance(request_data, dict):
+		raise ValueError('Invalid request_data: ' + str(request_data))
+
+	returning = request_data.get('returning') or {}
+
+	returned = {}
+	# Execute deletes within a transaction so an error will ROLLBACK 
+	#	any would-be successful deletes
+	with WriteSession() as session, session.begin():
+		for table_name, id_list in request_data.items():
+			if table_name not in tables:
+				raise ValueError(f'"{table_name}" not a valid table name')
+			if not isinstance(id_list, list):
+				raise ValueError(f'invalid ID list for table {table_name}: {str(id_list)}')
+			# make sure all IDs are integers
+			try:
+				id_list = [int(id_) for id_ in id_list]
+			except:
+				raise ValueError(f'invalid ID for table {table_name}: {str(id_list)}')
+			if len(id_list) == 0:
+				continue
+			returned |= delete_from_table(session, table_name, id_list, returning)
 
 	return jsonify({
 		'data': returned

--- a/web/js/backcountry.js
+++ b/web/js/backcountry.js
@@ -324,6 +324,48 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 	}
 
 
+	/*
+	Override the super class' saveEdits method to check if there is 
+	at least one route saved for the group. If not, warn the user
+	that this group won't appear in query results
+	*/
+	saveEdits({suppressRouteWarning=false}={}) {
+		const nRoutes = $('#routes-accordion .card:not(.cloneable)').length;
+		const isNewGroup = isNull($('#input-expedition_name').data('table-id'));
+		// Show the warning only if 
+		//	1. it isn't explicitly suppressed
+		//	2. this is a new group (don't show if user is editing an existing group)
+		//	3. there aren't any routes
+		if (!suppressRouteWarning && isNewGroup && nRoutes === 0) {
+			hideLoadingIndicator();
+			const message = 'You have not yet selected any routes for this backcountry' +
+				' group. You can still save your edits but the group will not appear in' +
+				' any query results or on the <strong>Mountain Stats This Season</strong>' +
+				' table of the home page. To add a route: ' + 
+				`<ol> 
+					<li>Click the <strong>Add location</strong> button</li>
+					<li>Click the <strong>Add member</strong> button</li>
+					<li>Click the <strong>Save</strong> button</li>
+					<li>Click the <strong>Add route</strong> button </li>
+				</ol>
+				` +
+				' Would you like to save this backcountry group <strong>without</strong> adding a route?'
+			const onConfirmClick = () => {$('#alert-modal .confirm-button').click(() => super.saveEdits())}
+			this.showModal(
+				message, 
+				'No Route Selected', 
+				{
+					modalType: 'yes/no', 
+					eventHandlerCallable: onConfirmClick
+				}
+			)
+		} else {
+			super.saveEdits();
+		}
+
+	}
+
+
 	addNewBCRoute($routeList) {
 		if ($routeList.closest('.card').is('.new-card')) {
 			const message = 
@@ -331,7 +373,9 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 				' Would you like to save all of your edits now?';
 			const onConfirmClickHandler = () => {
 				$('#alert-modal .confirm-button').click(() => {
-					this.saveEdits()
+					// Don't show routes warning because in order to add 
+					//	a route, the user has to save the location first
+					this.saveEdits({suppressRouteWarning: true})
 				});
 			}
 			this.showModal(

--- a/web/js/backcountry.js
+++ b/web/js/backcountry.js
@@ -729,11 +729,24 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 	}
 
 
+	clearExpeditionInfo({hideEditButtons=true, triggerChange=false}={}) {
+
+		const mainMap = this.maps.main;
+		// clear map layers
+		for (const layer of mainMap.layers) {
+			mainMap.map.removeLayer(layer);
+		}
+		mainMap.layers = [];
+
+		super.clearExpeditionInfo({hideEditButtons: hideEditButtons, triggerChange: triggerChange})
+	}
+
 	/*
 	Thin wrapper for ClimberDBExpeditions to set the locations on the map and 
 	update card headers
 	*/
 	fillFieldValues(triggerChange=true) {
+
 		super.fillFieldValues(triggerChange);
 
 		// Set location card labels

--- a/web/js/backcountry.js
+++ b/web/js/backcountry.js
@@ -496,11 +496,24 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 						for (const el of $mountainFields.closest('.data-list-item')) {
 							this.deleteBCRoute($(el), {confirm: false});
 							this.addNewBCRoute($routeList);
+							this.updateBCMountainOptions($mountainFields, newMountainCodes);
 						}
 					});
-					// When the user clicks either button, update 
-					$('#alert-modal .generic-button').click(() => {
-						this.updateBCMountainOptions($mountainFields, newMountainCodes);
+					// When the user clicks the No button, update mountain options including the 
+					//	current selection(s)
+					$('#alert-modal .deny-button').click(() => {
+						
+						// Get id/value pairs of existing mountain fields
+						const currentMountains = Object.fromEntries(
+							$mountainFields.map((_, el) => [[el.id, el.value]]).get() 
+						);
+
+						this.updateBCMountainOptions($mountainFields, [...Object.values(currentMountains), ...newMountainCodes]);
+						
+						// Set values of mountains since options were wiped
+						for (const [id, value] of Object.entries(currentMountains)) {
+							$('#' + id).val(value);
+						}
 					})
 				}
 

--- a/web/js/backcountry.js
+++ b/web/js/backcountry.js
@@ -414,6 +414,15 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 	}
 
 
+	onAddRouteButtonClick(e) {
+		if (!$('#expedition-members-accordion .card:not(.cloneable)').length) {
+			this.showModal('You must add at least one backcountry group member before you can add a route.', 'Invalid Action');
+			return;
+		}
+
+		this.addNewBCRoute($($(e.target).data('target')));
+	}
+
 	/*
 	Update the coordinate fields when the location name field changes
 	*/
@@ -691,7 +700,7 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 		});
 
 		$(document).on('click', '.add-bc-route-button', e => {
-			this.addNewBCRoute($($(e.target).data('target')));
+			this.onAddRouteButtonClick(e);
 		});
 
 		$(document).on('click', '.delete-bc-route-button', e => {

--- a/web/js/backcountry.js
+++ b/web/js/backcountry.js
@@ -567,6 +567,7 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 
 
 	removeLocationCard($locationCard) {
+		const locationCardIndex = $locationCard.index(this.locationCardIndexSelector);
 		$locationCard.fadeRemove({
 			onRemove: () => {
 				this.removeLocationFromMap(locationCardIndex);

--- a/web/js/backcountry.js
+++ b/web/js/backcountry.js
@@ -587,9 +587,9 @@ class ClimberDBBackcountry extends ClimberDBExpeditions {
 		const isLocationCard = $locationCard.closest('.accordion').is('#locations-accordion');
 
 		if (isLocationCard) {
-			const locationCardIndex = $locationCard.index(this.locationCardIndexSelector);
+			
 			if ($locationCard.is('.new-card')) {
-				for (const el of $locationCard.find('.bc-route-list > .data-list-item')) {
+				for (const el of $locationCard.find('.bc-route-list > .data-list-item:not(.cloneable)')) {
 					this.deleteBCRoute($(el))
 				}
 				this.removeLocationCard($locationCard);

--- a/web/js/climberdb.js
+++ b/web/js/climberdb.js
@@ -253,8 +253,8 @@ class ClimberDB {
 				'<button class="generic-button secondary-button modal-button close-modal" data-dismiss="modal">Cancel</button>' +
 				'<button class="generic-button modal-button close-modal confirm-button" data-dismiss="modal">OK</button>'
 			: modalType === 'yes/no' ? 
-				'<button class="generic-button modal-button secondary-button close-modal" data-dismiss="modal">No</button>' +
-				'<button class="generic-button modal-button primary-button close-modal confirm-button" data-dismiss="modal>Yes</button>'
+				'<button class="generic-button secondary-button modal-button close-modal deny-button" data-dismiss="modal">No</button>' +
+				'<button class="generic-button modal-button close-modal danger-button confirm-button" data-dismiss="modal">Yes</button>'
 			:
 			'<button class="generic-button modal-button close-modal confirm-button" data-dismiss="modal">OK</button>'
 			;
@@ -1005,6 +1005,25 @@ class ClimberDB {
 		});
 	}
 
+	/*
+	Delete rows by ID from one or more tables.
+	@param deleteIDs - object in the form {tableName: [id1, id2]}
+	@param returning [optional] - object in the form {tableName: [column1, column2]}
+		to specify 
+	*/
+	deleteFromMultipleTables(deleteIDs, {returning={}}={}) {
+
+		var requestData = deleteIDs;
+		if (Object.keys(returning).length)
+				requestData.returning = returning;
+
+		return $.post({
+			url: '/flask/db/delete/from_multiple_tables',
+			data: JSON.stringify(requestData),
+			contentType: 'application/json'
+		})
+
+	}
 
 	/*
 	*/
@@ -1812,11 +1831,15 @@ class ClimberDB {
 						columns: {}
 					};
 				}
-				if (info.foreign_table_name) {
-					this.tableInfo.tables[tableName].foreignColumns.push({
-						foreignTable: info.foreign_table_name,
-						column: info.column_name
-					});
+				const foreignColumnInfo = {
+					foreignTable: info.foreign_table_name,
+					column: info.column_name
+				}
+				if (
+						info.foreign_table_name && 
+						!this.tableInfo.tables[tableName].foreignColumns.map(JSON.stringify).includes(JSON.stringify(foreignColumnInfo))
+					) {
+					this.tableInfo.tables[tableName].foreignColumns.push(foreignColumnInfo);
 				}
 
 				this.tableInfo.tables[tableName].columns[info.column_name] = {...info};

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -1342,7 +1342,8 @@ class ClimberDBExpeditions extends ClimberDB {
 				.data-list-item:not(.cloneable), 
 				.card:not(.cloneable) .tab-pane,
 				#expedition-members-accordion .card:not(.cloneable) .card-header,
-				#expedition-data-container
+				#expedition-data-container,
+				#locations-accordion
 			`)
 			.has('.input-field.dirty, .input-field:required:invalid');
 		

--- a/web/js/expeditions.js
+++ b/web/js/expeditions.js
@@ -4002,7 +4002,7 @@ class ClimberDBExpeditions extends ClimberDB {
 				
 				this.fillFieldValues(false);//don't trigger change
 				// If the data are being re-loaded after a save, show the cards and tabs that were open before
-				if (!showOnLoadWarnings && $openCards.length) {
+				if (!showOnLoadWarnings && $openCards.length && $activeTabs.length) {
 					$(openCardIDs).addClass('show');
 					//$('.nav-tabs .nav-link.active').removeClass('active');
 					$(activeTabIDs).click();


### PR DESCRIPTION
In addition to moving the routes UI to the BC locations card, these changes fix a couple unrelated but adjacent bugs:
1. Itinerary locations was previously excluded from validation
2. map layers weren't removed when clearing input fields

closes #149
Also closes #148 because with the change to update the mountain when the location name changes, mountains are no longer duplicated